### PR TITLE
enforces east-const qualifier style

### DIFF
--- a/firmware/.clang-format
+++ b/firmware/.clang-format
@@ -12,3 +12,4 @@ IndentWidth: 4
 TabWidth: 4
 AccessModifierOffset: -4
 AllowShortFunctionsOnASingleLine: Empty
+QualifierAlignment: Right


### PR DESCRIPTION
Adds a clang format rule to enforce the east-const style.

`const float x = 10` will now be converted to `float const x = 10`

This style is most useful when dealing with const pointers and pointers to const objects. See [this explanation](https://isocpp.org/wiki/faq/const-correctness#const-ref-alt). _I recommend reading that whole page, I learned a lot about the const qualifier and realized I had been using it incorrectly._

With respect to the google c++ guide, the `const float` style is [encouraged but not required](https://google.github.io/styleguide/cppguide.html#Use_of_const), so this change does not violate the guide, although I am open to rejecting this change.

