### PR TITLE
Making cubemx/generate.mk standalone

### DIFF
--- a/firmware/projects/DemoProject/platforms/stm32f767/cubemx/CMakeLists.txt
+++ b/firmware/projects/DemoProject/platforms/stm32f767/cubemx/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT STM32CubeMX)
 endif()
 
 execute_process(
-	COMMAND ${CMAKE_MAKE_PROGRAM} "--file" "generate.mk" "CUBEMX_PATH=${STM32CubeMX}" "IOC_FILE=${CMAKE_CURRENT_SOURCE_DIR}/board_config.ioc"
+	COMMAND ${CMAKE_MAKE_PROGRAM} "--file" "generate.mk"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 execute_process(

--- a/firmware/projects/DemoProject/platforms/stm32f767/cubemx/CMakeLists.txt
+++ b/firmware/projects/DemoProject/platforms/stm32f767/cubemx/CMakeLists.txt
@@ -2,11 +2,6 @@
 # January 8, 2023
 
 message(STATUS "Building CubeMX objects with the auto-generated Makefile")
-find_program(STM32CubeMX STM32CubeMX)
-
-if(NOT STM32CubeMX)
-	message(FATAL_ERROR "STM32CubeMX not found in PATH")
-endif()
 
 execute_process(
 	COMMAND ${CMAKE_MAKE_PROGRAM} "--file" "generate.mk"

--- a/firmware/projects/DemoProject/platforms/stm32f767/cubemx/generate.mk
+++ b/firmware/projects/DemoProject/platforms/stm32f767/cubemx/generate.mk
@@ -1,5 +1,12 @@
-CUBEMX_PATH =
-IOC_FILE = 
+ifeq ($(OS),Windows_NT)
+    CUBEMX_PATH := $(shell where STM32CubeMX)
+    # Convert path to Windows-style and add .exe extension
+    CUBEMX_PATH := $(subst \,\\,$(CUBEMX_PATH))
+else
+    CUBEMX_PATH := $(shell which STM32CubeMX)
+endif
+
+IOC_FILE = board_config.ioc
 
 CUBEMX_GEN_SCRIPT = cubemx_script.txt
 

--- a/firmware/projects/TMS/platforms/stm32f767/cubemx/CMakeLists.txt
+++ b/firmware/projects/TMS/platforms/stm32f767/cubemx/CMakeLists.txt
@@ -2,14 +2,9 @@
 # January 8, 2023
 
 message(STATUS "Building CubeMX objects with the auto-generated Makefile")
-find_program(STM32CubeMX STM32CubeMX)
-
-if(NOT STM32CubeMX)
-	message(FATAL_ERROR "STM32CubeMX not found in PATH")
-endif()
 
 execute_process(
-	COMMAND ${CMAKE_MAKE_PROGRAM} "--file" "generate.mk" "CUBEMX_PATH=${STM32CubeMX}" "IOC_FILE=${CMAKE_CURRENT_SOURCE_DIR}/board_config.ioc"
+	COMMAND ${CMAKE_MAKE_PROGRAM} "--file" "generate.mk"
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 execute_process(

--- a/firmware/projects/TMS/platforms/stm32f767/cubemx/generate.mk
+++ b/firmware/projects/TMS/platforms/stm32f767/cubemx/generate.mk
@@ -1,5 +1,12 @@
-CUBEMX_PATH =
-IOC_FILE = 
+ifeq ($(OS),Windows_NT)
+    CUBEMX_PATH := $(shell where STM32CubeMX)
+    # Convert path to Windows-style and add .exe extension
+    CUBEMX_PATH := $(subst \,\\,$(CUBEMX_PATH))
+else
+    CUBEMX_PATH := $(shell which STM32CubeMX)
+endif
+
+IOC_FILE = board_config.ioc
 
 CUBEMX_GEN_SCRIPT = cubemx_script.txt
 


### PR DESCRIPTION
Closes #47 

- Added hardcoded .ioc file name in generate.mk
- Added logic to grab the STM32CubeMX path depending on platform (windows / linux)

Testing:
I was able to generate by only running the command below with no extra arguments:

`make -f generate.mk`
