### PR TITLE
Implemented Target Deep Clean

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -12,9 +12,18 @@ clean: FORCE
 	rm $(BUILD_DIR) -rf
 
 deepclean: clean
-	@echo "Deleting generated files and directories in $(CUBEMX_DIR) that are ignored by Git"
+ifeq ($(findstring stm32,$(PLATFORM)),stm32)
+	@echo "Deleting files and directories in $(CUBEMX_DIR) that are ignored by Git"
 	@cd $(CUBEMX_DIR) && \
-		git check-ignore * | xargs -I{} rm -rf "{}"
+		for file in $$(ls -R); do \
+			if git check-ignore "$$file" >/dev/null; then \
+				echo "Deleting $$file"; \
+				rm -rf "$$file"; \
+			fi; \
+		done
+else
+	@echo "Skipping deepclean for platform $(PLATFORM)"
+endif
 
 st-flash: build
 	st-flash --reset write $(BUILD_DIR)/main.bin 0x08000000

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -4,8 +4,6 @@ PROJECT =
 BUILD_DIR = build/$(PROJECT)/$(PLATFORM)
 CUBEMX_DIR := projects/$(PROJECT)/platforms/$(PLATFORM)/cubemx
 
-KEEP_FILES := .gitignore CMakeLists.txt README board_config.ioc generate.mk
-
 build: FORCE
 	cmake -B $(BUILD_DIR) -S. -G"Unix Makefiles" -DPROJECT=$(PROJECT) -DPLATFORM=$(PLATFORM) 
 	cmake --build $(BUILD_DIR)
@@ -14,18 +12,9 @@ clean: FORCE
 	rm $(BUILD_DIR) -rf
 
 deepclean: clean
-	@echo "Deleting files and directories in $(CUBEMX_DIR) except $(KEEP_FILES)"
-	@cd $(CUBEMX_DIR) && for file in *; do \
-		if ! echo "$(KEEP_FILES)" | grep -q "\\b$$file\\b"; then \
-			if [ -d "$$file" ]; then \
-				echo "Deleting directory $$file"; \
-				rm -rf "$$file"; \
-			else \
-				echo "Deleting file $$file"; \
-				rm -f "$$file"; \
-			fi; \
-		fi; \
-	done
+	@echo "Deleting generated files and directories in $(CUBEMX_DIR) that are ignored by Git"
+	@cd $(CUBEMX_DIR) && \
+		git check-ignore * | xargs -I{} rm -rf "{}"
 
 st-flash: build
 	st-flash --reset write $(BUILD_DIR)/main.bin 0x08000000

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -2,6 +2,9 @@ PLATFORM =
 PROJECT = 
 
 BUILD_DIR = build/$(PROJECT)/$(PLATFORM)
+CUBEMX_DIR := projects/$(PROJECT)/platforms/$(PLATFORM)/cubemx
+
+KEEP_FILES := .gitignore CMakeLists.txt README board_config.ioc generate.mk
 
 build: FORCE
 	cmake -B $(BUILD_DIR) -S. -G"Unix Makefiles" -DPROJECT=$(PROJECT) -DPLATFORM=$(PLATFORM) 
@@ -9,6 +12,20 @@ build: FORCE
 
 clean: FORCE
 	rm $(BUILD_DIR) -rf
+
+deepclean: clean
+	@echo "Deleting files and directories in $(CUBEMX_DIR) except $(KEEP_FILES)"
+	@cd $(CUBEMX_DIR) && for file in *; do \
+		if ! echo "$(KEEP_FILES)" | grep -q "\\b$$file\\b"; then \
+			if [ -d "$$file" ]; then \
+				echo "Deleting directory $$file"; \
+				rm -rf "$$file"; \
+			else \
+				echo "Deleting file $$file"; \
+				rm -f "$$file"; \
+			fi; \
+		fi; \
+	done
 
 st-flash: build
 	st-flash --reset write $(BUILD_DIR)/main.bin 0x08000000

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -15,12 +15,7 @@ deepclean: clean
 ifeq ($(findstring stm32,$(PLATFORM)),stm32)
 	@echo "Deleting files and directories in $(CUBEMX_DIR) that are ignored by Git"
 	@cd $(CUBEMX_DIR) && \
-		for file in $$(ls -R); do \
-			if git check-ignore "$$file" >/dev/null; then \
-				echo "Deleting $$file"; \
-				rm -rf "$$file"; \
-			fi; \
-		done
+		find | xargs git check-ignore | xargs rm -rf
 else
 	@echo "Skipping deepclean for platform $(PLATFORM)"
 endif

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -14,8 +14,8 @@ clean: FORCE
 deepclean: clean
 ifeq ($(findstring stm32,$(PLATFORM)),stm32)
 	@echo "Deleting files and directories in $(CUBEMX_DIR) that are ignored by Git"
-	@cd $(CUBEMX_DIR) && \
-		find | xargs git check-ignore | xargs rm -rf
+	@cd $(CUBEMX_DIR)
+	@find | xargs git check-ignore | xargs rm -rf
 else
 	@echo "Skipping deepclean for platform $(PLATFORM)"
 endif


### PR DESCRIPTION
Closes #51 

Implemented Deep clean which will call original clean and remove all generated files under cubemx. Unsure if that is the way you want it to be deleted since it happens at the firmware level.

It will basically delete any folder/file under the cubemx directory that is not in the KEEP_FILE string.

TESTING:
Built the project a few times and deep cleaned it to make sure it only deleted generated content.