### PR TITLE
Adding / upgrading existing header guards to #pragma once

### DIFF
--- a/firmware/mcal/stm32f767/periph/adc.h
+++ b/firmware/mcal/stm32f767/periph/adc.h
@@ -46,5 +46,3 @@ public:
 };
 
 }  // namespace mcal::periph
-
-#endif

--- a/firmware/mcal/stm32f767/periph/adc.h
+++ b/firmware/mcal/stm32f767/periph/adc.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-11-09
 
-#ifndef MCAL_STM32F767_PERIPH_ADC_H_
-#define MCAL_STM32F767_PERIPH_ADC_H_
+#pragma once
 
 #include <cstdint>
 

--- a/firmware/mcal/stm32f767/periph/gpio.h
+++ b/firmware/mcal/stm32f767/periph/gpio.h
@@ -45,5 +45,3 @@ public:
 };
 
 }  // namespace mcal::periph
-
-#endif

--- a/firmware/mcal/stm32f767/periph/gpio.h
+++ b/firmware/mcal/stm32f767/periph/gpio.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-11-08
 
-#ifndef MCAL_STM32F767_PERIPH_GPIO_H_
-#define MCAL_STM32F767_PERIPH_GPIO_H_
+#pragma once
 
 #include <cstdint>
 

--- a/firmware/mcal/stm32f767/periph/pwm.h
+++ b/firmware/mcal/stm32f767/periph/pwm.h
@@ -44,5 +44,3 @@ private:
 };
 
 }  // namespace mcal::periph
-
-#endif

--- a/firmware/mcal/stm32f767/periph/pwm.h
+++ b/firmware/mcal/stm32f767/periph/pwm.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-11-09
 
-#ifndef MCAL_STM32F767_PERIPH_PWM_H_
-#define MCAL_STM32F767_PERIPH_PWM_H_
+#pragma once
 
 #include <cstdint>
 

--- a/firmware/mcal/windows/periph/adc.h
+++ b/firmware/mcal/windows/periph/adc.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-12-10
 
-#ifndef MCAL_WINDOWS_PERIPH_ADC_H_
-#define MCAL_WINDOWS_PERIPH_ADC_H_
+#pragma once
 
 #include <cstdint>
 #include <iostream>

--- a/firmware/mcal/windows/periph/adc.h
+++ b/firmware/mcal/windows/periph/adc.h
@@ -33,5 +33,3 @@ private:
 };
 
 }  // namespace mcal::periph
-
-#endif

--- a/firmware/mcal/windows/periph/gpio.h
+++ b/firmware/mcal/windows/periph/gpio.h
@@ -49,5 +49,3 @@ public:
 };
 
 }  // namespace mcal::periph
-
-#endif

--- a/firmware/mcal/windows/periph/gpio.h
+++ b/firmware/mcal/windows/periph/gpio.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-12-10
 
-#ifndef MCAL_WINDOWS_PERIPH_GPIO_H_
-#define MCAL_WINDOWS_PERIPH_GPIO_H_
+#pragma once
 
 #include <iostream>
 #include <string>

--- a/firmware/mcal/windows/periph/pwm.h
+++ b/firmware/mcal/windows/periph/pwm.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-12-10
 
-#ifndef MCAL_WINDOWS_PERIPH_PWM_H_
-#define MCAL_WINDOWS_PERIPH_PWM_H_
+#pragma once
 
 #include <iostream>
 #include <string>

--- a/firmware/mcal/windows/periph/pwm.h
+++ b/firmware/mcal/windows/periph/pwm.h
@@ -42,5 +42,3 @@ private:
 };
 
 }  // namespace mcal::periph
-
-#endif

--- a/firmware/projects/DemoMapper/inc/app.h
+++ b/firmware/projects/DemoMapper/inc/app.h
@@ -1,3 +1,5 @@
 /// @author Blake Freer
 /// @date 2024-02-04
 /// @note No app objects are required for this demo
+
+#pragma once

--- a/firmware/projects/DemoMapper/platforms/windows/bindings.h
+++ b/firmware/projects/DemoMapper/platforms/windows/bindings.h
@@ -1,2 +1,4 @@
 /// @author Blake Freer
 /// @date 2023-12-25
+
+#pragma once

--- a/firmware/projects/DemoProject/inc/app.h
+++ b/firmware/projects/DemoProject/inc/app.h
@@ -1,6 +1,8 @@
 /// @author Blake Freer
 /// @date 2023-12-25
 
+#pragma once
+
 #include "shared/periph/gpio.h"
 
 class Button {

--- a/firmware/shared/periph/adc.h
+++ b/firmware/shared/periph/adc.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-11-09
 
-#ifndef SHARED_PERIPH_ADC_H_
-#define SHARED_PERIPH_ADC_H_
+#pragma once
 
 #include <cstdint>
 

--- a/firmware/shared/periph/adc.h
+++ b/firmware/shared/periph/adc.h
@@ -16,5 +16,3 @@ public:
 };
 
 }  // namespace shared::periph
-
-#endif

--- a/firmware/shared/periph/gpio.h
+++ b/firmware/shared/periph/gpio.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-11-08
 
-#ifndef SHARED_PERIPH_GPIO_H_
-#define SHARED_PERIPH_GPIO_H_
+#pragma once
 
 #include "shared/util/peripheral.h"
 

--- a/firmware/shared/periph/gpio.h
+++ b/firmware/shared/periph/gpio.h
@@ -20,5 +20,3 @@ public:
 };
 
 }  // namespace shared::periph
-
-#endif

--- a/firmware/shared/periph/pwm.h
+++ b/firmware/shared/periph/pwm.h
@@ -18,5 +18,3 @@ public:
 };
 
 }  // namespace shared::periph
-
-#endif

--- a/firmware/shared/periph/pwm.h
+++ b/firmware/shared/periph/pwm.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-11-09
 
-#ifndef SHARED_PERIPH_PWM_H_
-#define SHARED_PERIPH_PWM_H_
+#pragma once
 
 #include <concepts>
 

--- a/firmware/shared/util/communication.h
+++ b/firmware/shared/util/communication.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-10-14
 
-#ifndef SHARED_UTIL_COMMUNICATION_H_
-#define SHARED_UTIL_COMMUNICATION_H_
+#pragma once
 
 #include "shared/util/noncopyable.h"
 

--- a/firmware/shared/util/communication.h
+++ b/firmware/shared/util/communication.h
@@ -11,5 +11,3 @@ namespace shared::util {
 class communication_base : private Noncopyable {};
 
 }  // namespace shared::util
-
-#endif

--- a/firmware/shared/util/data_structures/circular_queue.h
+++ b/firmware/shared/util/data_structures/circular_queue.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-12-02
 
-#ifndef SHARED_DATA_STRUCTURES_CIRCULAR_QUEUE_H_
-#define SHARED_DATA_STRUCTURES_CIRCULAR_QUEUE_H_
+#pragma once
 
 #include <concepts>
 #include <cstdint>

--- a/firmware/shared/util/data_structures/circular_queue.h
+++ b/firmware/shared/util/data_structures/circular_queue.h
@@ -66,5 +66,3 @@ private:
 };
 
 }  // namespace shared::util
-
-#endif

--- a/firmware/shared/util/moving_average.h
+++ b/firmware/shared/util/moving_average.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-12-02
 
-#ifndef SHARED_UTIL_MOVING_AVERAGE_H_
-#define SHARED_UTIL_MOVING_AVERAGE_H_
+#pragma once
 
 #include <concepts>
 

--- a/firmware/shared/util/moving_average.h
+++ b/firmware/shared/util/moving_average.h
@@ -41,5 +41,3 @@ private:
 };
 
 }  // namespace shared::util
-
-#endif

--- a/firmware/shared/util/noncopyable.h
+++ b/firmware/shared/util/noncopyable.h
@@ -2,8 +2,7 @@
 /// @date 2023-10-14
 /// @note Taken from Christopher Kormanyos
 
-#ifndef SHARED_UTIL_NONCOPYABLE_H_
-#define SHARED_UTIL_NONCOPYABLE_H_
+#pragma once
 
 namespace shared::util {
 

--- a/firmware/shared/util/noncopyable.h
+++ b/firmware/shared/util/noncopyable.h
@@ -22,5 +22,3 @@ private:
 };
 
 }  // namespace shared::util
-
-#endif

--- a/firmware/shared/util/peripheral.h
+++ b/firmware/shared/util/peripheral.h
@@ -24,5 +24,3 @@ class Peripheral {
 };
 
 } // namespace shared::util
-
-#endif

--- a/firmware/shared/util/peripheral.h
+++ b/firmware/shared/util/peripheral.h
@@ -1,8 +1,7 @@
 /// @author Blake Freer
 /// @date 2023-11-08
 
-#ifndef SHARED_UTIL_PERIPHERAL_H_
-#define SHARED_UTIL_PERIPHERAL_H_
+#pragma once
 
 #include "shared/util/noncopyable.h"
 


### PR DESCRIPTION
Closes #25 

Added / Updated existing header guards to #pragma once

TESTING:
Ran `make PLATFORM=stm32f767 PROJECT=DemoProject` and it compiled with no errors

I left an empty line in the files but Im not sure why github says the opposite.