### PR TITLE
removes bindings.h from DemoMapper 

### DIFF
--- a/firmware/projects/DemoMapper/main.cc
+++ b/firmware/projects/DemoMapper/main.cc
@@ -4,7 +4,6 @@
 #include <iostream>  // for demo only, will not work on other platforms
 
 #include "app.h"
-#include "bindings.h"
 #include "shared/util/mappers/clamper.h"
 #include "shared/util/mappers/linear_map.h"
 #include "shared/util/mappers/mapper.h"

--- a/firmware/projects/DemoMapper/platforms/windows/bindings.cc
+++ b/firmware/projects/DemoMapper/platforms/windows/bindings.cc
@@ -1,8 +1,6 @@
 /// @author Blake Freer
 /// @date 2023-12-25
 
-#include "bindings.h"
-
 #include <iostream>
 
 namespace bindings {}  // namespace bindings

--- a/firmware/projects/DemoMapper/platforms/windows/bindings.h
+++ b/firmware/projects/DemoMapper/platforms/windows/bindings.h
@@ -1,4 +1,0 @@
-/// @author Blake Freer
-/// @date 2023-12-25
-
-#pragma once


### PR DESCRIPTION
`bindings.h` is no longer used in any project but we forgot to remove it from DemoMapper