### PR TITLE
deepclean bugfix

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -14,8 +14,7 @@ clean: FORCE
 deepclean: clean
 ifeq ($(findstring stm32,$(PLATFORM)),stm32)
 	@echo "Deleting files and directories in $(CUBEMX_DIR) that are ignored by Git"
-	@cd $(CUBEMX_DIR)
-	@find | xargs git check-ignore | xargs rm -rf
+	find $(CUBEMX_DIR) | xargs git check-ignore | xargs rm -rf
 else
 	@echo "Skipping deepclean for platform $(PLATFORM)"
 endif


### PR DESCRIPTION
The `cd CUBEMX_FOLDER` has no effect in the Makefile deepclean target, so deepclean was attempting to remove all non-git tracked files, not just those in the specified cubemx directory. This PR fixes it by explicitly telling `find` which directory to look in