### PR TITLE
renames stm binary

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -32,6 +32,6 @@ else
 endif
 
 st-flash: build
-	st-flash --reset write $(BUILD_DIR)/main.bin 0x08000000
+	st-flash --reset write $(BUILD_DIR)/$(PROJECT).bin 0x08000000
 
 FORCE:

--- a/firmware/mcal/stm32f767/PostBuild.cmake
+++ b/firmware/mcal/stm32f767/PostBuild.cmake
@@ -5,7 +5,7 @@ add_custom_command(
 	TARGET main
 	POST_BUILD
 	COMMAND ${CMAKE_SIZE} $<TARGET_FILE:main>
-	COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:main> main.hex
-	COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:main> main.bin
+	COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:main> ${PROJECT}.hex
+	COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:main> ${PROJECT}.bin
 	# COMMAND ${CMAKE_OBJDUMP} -D -C $<TARGET_FILE:main> > main.s
 )


### PR DESCRIPTION
closes #29 
does not affect windows builds

importantly, this does NOT change the cmake target name from `main` to `<project>`, only the output `.bin` file. Changing the target name would require passing variables through all CMakelists and would be a nightmare