### PR TITLE
refactor(can-gen): :recycle: Improve CAN generation and build support.

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -111,12 +111,6 @@ add_subdirectory(${DIR_MCAL}) # provides "mcal-<name>" (library)
 add_subdirectory(${DIR_PROJECT}) # modifies "main" (executable)
 add_subdirectory(${DIR_PLATFORM}) # modifies "bindings" (library)
 
-set(DIR_ETL "${CMAKE_CURRENT_SOURCE_DIR}/third-party/etl/include")
-target_include_directories(main
-    PUBLIC
-    ${DIR_ETL}
-)
-
 target_link_libraries(main PRIVATE shared)
 target_link_libraries(main PRIVATE bindings)
 

--- a/firmware/mcal/raspi/periph/can.h
+++ b/firmware/mcal/raspi/periph/can.h
@@ -30,7 +30,8 @@ public:
 
     void Setup() {
         // Create a socket
-        sock_ = socket(PF_CAN, SOCK_RAW, CAN_RAW) if (sock_ < 0) {
+        sock_ = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+        if (sock_ < 0) {
             perror("Error creating socket");
             return;
         }

--- a/firmware/mcal/windows/periph/can.h
+++ b/firmware/mcal/windows/periph/can.h
@@ -15,7 +15,7 @@
 #include "shared/comms/can/raw_can_msg.h"
 #include "shared/periph/can.h"
 
-namespace mcal::periph {
+namespace mcal::windows::periph {
 
 class CanBase : public shared::periph::CanBase {
 public:
@@ -48,4 +48,4 @@ private:
     std::string iface_;
 };
 
-}  // namespace mcal::periph
+}  // namespace mcal::windows::periph

--- a/firmware/projects/DemoCan/CMakeLists.txt
+++ b/firmware/projects/DemoCan/CMakeLists.txt
@@ -29,10 +29,15 @@ target_sources(main
 )
 add_dependencies(main generated_can)
 
+
 target_include_directories(main
-	PRIVATE
-	${CMAKE_CURRENT_SOURCE_DIR}/inc
+PRIVATE
+${CMAKE_CURRENT_SOURCE_DIR}/inc
 )
+
+# Link ETL which is needed for generated/can/msg_registry.h
+add_subdirectory(${CMAKE_SOURCE_DIR}/third-party/etl ${CMAKE_BINARY_DIR}/third-party)
+target_link_libraries(main PRIVATE etl)
 
 # Notice that we don't include any mcal/ subdirectory in this CMake file.
 # The master CMakeLists handles platform selection and library linking.

--- a/firmware/projects/DemoCan/CMakeLists.txt
+++ b/firmware/projects/DemoCan/CMakeLists.txt
@@ -31,8 +31,8 @@ add_dependencies(main generated_can)
 
 
 target_include_directories(main
-PRIVATE
-${CMAKE_CURRENT_SOURCE_DIR}/inc
+	PRIVATE
+	${CMAKE_CURRENT_SOURCE_DIR}/inc
 )
 
 # Link ETL which is needed for generated/can/msg_registry.h

--- a/firmware/projects/DemoCan/platforms/windows/bindings.cc
+++ b/firmware/projects/DemoCan/platforms/windows/bindings.cc
@@ -5,7 +5,7 @@
 #include "shared/periph/can.h"
 
 namespace mcal {
-using namespace periph::windows;
+using namespace windows::periph;
 
 CanBase veh_can_base{"vcan0"};
 }  // namespace mcal

--- a/scripts/cangen/main.py
+++ b/scripts/cangen/main.py
@@ -3,69 +3,71 @@ Author: Samuel Parent
 Date: 2024-04-13
 """
 
-from can_generator import CanGenerator
-import yaml
 import argparse
 import logging
 import os
 
-SCRIPTS_TO_PROJECTS_DIR = "../../firmware/projects"
-SCRIPTS_TO_DBCS = "../../firmware/dbcs"
-SCRIPTS_TO_TEMPLATES_DIR = "templates"
-CONFIG_FILE_PATH = "config.yaml"
-CAN_MESSAGES_TEMPLATE_FILENAME = "can_messages.h.jinja2"
-MSG_REGISTRY_FILENAME = "msg_registry.h.jinja2"
+import can_generator
+import yaml
+
+# Generate a set of directory paths, all based on this file's location
+DIR_THIS_FILE = os.path.abspath(os.path.dirname(__file__))
+
+DIR_FIRMWARE = os.path.join(DIR_THIS_FILE, os.pardir, os.pardir, "firmware")
+DIR_PROJECTS = os.path.join(DIR_FIRMWARE, "projects")
+DIR_DBCS = os.path.join(DIR_FIRMWARE, "dbcs")
+
+CONFIG_FILE_NAME = "config.yaml"
 OUTPUT_DIR = "generated/can"
+
+DIR_TEMPLATES = os.path.join(DIR_THIS_FILE, "templates")
+CAN_MESSAGES_TEMPLATE_FILENAME = "can_messages.h.jinja2"
+MSG_REGISTRY_TEMPLATE_FILENAME = "msg_registry.h.jinja2"
+
 
 logging.basicConfig(level="INFO", format="%(levelname)-8s| (%(name)s) %(message)s")
 
-def read_yaml_file(yaml_file):
-    with open(yaml_file, "r") as file:
-        return yaml.safe_load(file)
+
+def parse():
+    parser = argparse.ArgumentParser(description="DBC to C code generator")
+    parser.add_argument(
+        "--project", type=str, required=True, help="Name of the project"
+    )
+
+    # If parsing fails (ex incorrect or no arguments provided) then this exits with
+    # code 2.
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="DBC to C code generator")
-    parser.add_argument("--project", type=str, required=True, help="Name of the project")
-
-    try:
-        args = parser.parse_args()
-    except argparse.ArgumentError:
-        parser.print_help()
-        exit(1)
-
-    project_dir = args.project
-    this_script_dir = os.path.dirname(os.path.abspath(__file__))
 
     # Change directory to the project folder
-    os.chdir(os.path.join(this_script_dir, SCRIPTS_TO_PROJECTS_DIR, project_dir))
+    args = parse()
+    project_folder_name = args.project
+    os.chdir(os.path.join(DIR_PROJECTS, project_folder_name))
 
-    config = read_yaml_file(CONFIG_FILE_PATH)
+    # Read & Parse the config file
+    with open(CONFIG_FILE_NAME, "r") as file:
+        config = yaml.safe_load(file)
 
     our_node = config["canGen"]["ourNode"].upper()
     bus_name = config["canGen"]["busName"].capitalize()
     dbc_files = config["canGen"]["dbcFiles"]
-    output_dir = OUTPUT_DIR
 
-    dbc_file_paths = [
-        os.path.join(this_script_dir, SCRIPTS_TO_DBCS, dbc) for dbc in dbc_files
-    ]
+    dbc_file_paths = [os.path.join(DIR_DBCS, dbc) for dbc in dbc_files]
 
-    can_msg_template_path = os.path.join(
-        this_script_dir, SCRIPTS_TO_TEMPLATES_DIR, CAN_MESSAGES_TEMPLATE_FILENAME
+    can_messages_template_path = os.path.join(
+        DIR_TEMPLATES, CAN_MESSAGES_TEMPLATE_FILENAME
     )
     msg_registry_template_path = os.path.join(
-        this_script_dir, SCRIPTS_TO_TEMPLATES_DIR, MSG_REGISTRY_FILENAME
-    )
-
-    can_generator = CanGenerator(
-        can_messages_template_path=can_msg_template_path,
-        msg_registry_template_path=msg_registry_template_path,
+        DIR_TEMPLATES, MSG_REGISTRY_TEMPLATE_FILENAME
     )
 
     can_generator.generate_code(
-        dbc_files=dbc_file_paths,
-        our_node=our_node,
-        bus_name=bus_name,
-        output_dir=output_dir,
+        dbc_file_paths,
+        our_node,
+        bus_name,
+        OUTPUT_DIR,
+        can_messages_template_path,
+        msg_registry_template_path,
     )

--- a/scripts/cangen/requirements.txt
+++ b/scripts/cangen/requirements.txt
@@ -1,0 +1,15 @@
+argparse-addons==0.12.0
+bitstruct==8.19.0
+cantools==39.4.5
+crccheck==1.3.0
+diskcache==5.6.3
+Jinja2==3.1.3
+MarkupSafe==2.1.5
+numpy==1.26.4
+packaging==24.0
+python-can==4.3.1
+pywin32==306
+PyYAML==6.0.1
+textparser==0.24.0
+typing_extensions==4.11.0
+wrapt==1.16.0


### PR DESCRIPTION
Convert ETL from an include path to a proper target in CMake. Refactor cangen Python code to use a functional paradigm and be more "Pythonic"

Closes #104 
Closes #105

Python Validation: for democan, the new script generates files that are character-for-character equal to the old script. 