### PR TITLE
Fix absolute paths issue on Windows

### DIFF
--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -12,8 +12,8 @@ AUTOGEN_CUBEMX = ON
 CUBEMX_GEN_SCRIPT = cubemx_script.txt
 
 # Get the directory of this file since it is called from other locations
-BUILD_SYS_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-CUSTOM_TARGETS_FILE = $(BUILD_SYS_DIR)/custom_cubemx_targets.mk
+BUILD_SYS_DIR:=$(dir $(MAKEFILE_LIST))
+CUSTOM_TARGETS_FILE = $(BUILD_SYS_DIR)custom_cubemx_targets.mk
 
 # Copy the CubeMX makefile and custom targets into a new makefile
 CustomMakefile.mk: Makefile $(CUSTOM_TARGETS_FILE)


### PR DESCRIPTION
Using realpath and abspath in a makefile that is invoked from another makefile seems to not work on Windows in at least Make 3.8.1 (version included in Git Bash for me).

Using abspath/realpath in this case will append to an existing path, producing a path such as `D:/STWorkspace/racecar/firmware/projects/DemoProject/platforms/stm32f767/cubemx/D:/STWorkspace/racecar/firmware/cmake`.

Haven't tested this fix on Linux since I don't have a setup for it right now, but it should still produce the correct filepath. Not sure how common this issue would be for building on windows but it's only a minor inconvenience anyway.

For bug report: [https://lists.gnu.org/archive/html/bug-make/2008-06/msg00054.html](https://lists.gnu.org/archive/html/bug-make/2008-06/msg00054.html)