### PR TITLE
fixed #175 CAN not working with lowercase

### DIFF
--- a/scripts/cangen/can_generator.py
+++ b/scripts/cangen/can_generator.py
@@ -48,12 +48,17 @@ def _parse_dbc_files(dbc_files: List[str]) -> Database:
 
     return can_db
 
+def _normalize_node_name(
+    node_name: str
+) -> str:
+    return node_name.upper()
 
 def _filter_messages_by_node(
     messages: List[Message], node: str
 ) -> Tuple[List[Message], List[Message]]:
-    tx_msgs = [msg for msg in messages if node in msg.senders]
-    rx_msgs = [msg for msg in messages if node in msg.receivers]
+    normalized_node_name = _normalize_node_name(node)
+    tx_msgs = [msg for msg in messages if normalized_node_name in map(_normalize_node_name, msg.senders)]
+    rx_msgs = [msg for msg in messages if normalized_node_name in map(_normalize_node_name, msg.receivers)]
 
     logger.debug(
         f"Filtered messages by node: {node}. "

--- a/scripts/cangen/main.py
+++ b/scripts/cangen/main.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
     config_file_path = os.path.abspath(CONFIG_FILE_NAME)
 
-    our_node = config["canGen"]["ourNode"].upper()
+    our_node = config["canGen"]["ourNode"]
     bus_list = config["canGen"]["busses"]
     output_path = config["canGen"].get("outputPath", DEFAULT_OUTPUT_DIR)
 


### PR DESCRIPTION
fixed the issue #175, allowing the cangen to work successfully regardless of the capitalization of node names in the .dbc file for a project and the node name in the config.yaml file.