### PR TITLE
Improved Dev Setup documentation

### DIFF
--- a/docs/docs/firmware/dev-setup.md
+++ b/docs/docs/firmware/dev-setup.md
@@ -13,26 +13,32 @@ Follow these steps to begin developing in `racecar/firmware`.
 
     1. We will use Chocolatey to install most dependencies. Go to <https://chocolatey.org/install#individual> and follow the instructions under "Install Chocolatey for Individual Use".
 
-        Open a Command Prompt __as administrator__ and run
+    2. Open a Command Prompt __as administrator__ and run
 
         ```text
         choco upgrade git msys2 make cmake -y
         ```
         
-    2. Install the newest version of Python from <https://www.python.org/downloads/>. When installing, ensure `Add python.exe to PATH` is checked.
+    3. Install the newest version of Python from <https://www.python.org/downloads/>. When installing, ensure `Add python.exe to PATH` is checked.
 
-    3. Open an MSYS2 terminal by searching `msys2` in the Start Menu :material-microsoft-windows:. Install the GNU toolchain with
+    4. Open the MSYS2 directory by searching `msys2` in the Start Menu :material-microsoft-windows: and choosing "Open file location." Run `msys2.exe` to open a terminal and install the GNU toolchain with
 
         ```bash
-        pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
+        pacman -Syuu
+        pacman -S mingw-w64-x86_64-toolchain
         ```
 
         Press ++enter++ when prompted to "Enter a selection."
 
-        Add the MSYS2 ucrt64 binary directory to your PATH. You can find this path by searching `msys2` in the Start menu, clicking "Open File Location" then following `ucrt64/bin`.
-
-    4. Install the Arm GNU Toolchain from <https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads>.
+        Add the MSYS2 mingw64 binary and library directories to your PATH. These paths will be of the form
         
+        ```text
+        C:\path-to-msys2\mingw64\bin
+        C:\path-to-msys2\mingw64\lib
+        ```
+
+    5. Install the Arm GNU Toolchain from <https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads>.
+
         1. Download the `.exe` installer under "Windows hosted cross toolchains -> AArch32 bare-metal target (arm-none-eabi)".
         2. Run the installer.
         3. After the installer finishes, check `Add path to environment variable.`
@@ -50,7 +56,7 @@ Follow these steps to begin developing in `racecar/firmware`.
         sudo apt-get install software-properties-common
         sudo add-apt-repository ppa:deadsnakes/ppa
         sudo apt-get update
-        sudo apt-get install git-all build-essential cmake python3.12 wget
+        sudo apt-get install git-all build-essential cmake python3.12 wget gcc-13
         ```
 
     3. Install the Arm GNU Toolchain.
@@ -71,7 +77,7 @@ Follow these steps to begin developing in `racecar/firmware`.
 
 Check that all programs were installed and have an acceptable version.
 
-_Do not copy the `# version comments`_
+_Do not copy the `# version comments`._
 
 ```{.bash .no-copy}
 python --version  # >= 3.10, use python3 on Linux / Mac
@@ -111,15 +117,23 @@ CubeMX is a program which generates configuration code for our microcontrollers.
 
 4. Wait for the program to stop printing to your terminal. Press ++question+enter++ to display the `MX>` prompt. Login with your `username` and `password`.
 
-        MX> login username password y
+    ```{.text .no-copy}
+    login username password y
+    ```
 
-    Do not omit the `y` at the end! You can close CubeMX now.
+    Do not omit the `y` at the end!
+
+5. Install the STM32F7 firmware pack.
+
+    ```text
+    swmgr install stm32cube_f7_1.17.2 ask
+    ```
+
+    You can close CubeMX now by typing `exit`.
 
 ### STM32CubeProgrammer
 
 Download and install version 2.16 or newer from <https://www.st.com/en/development-tools/stm32cubeprog.html>.
-
-It does not need to be on your PATH.
 
 ## Clone the Repository
 
@@ -127,23 +141,23 @@ Navigate to a directory where you would like to hold the `racecar` repo (I used 
 
     git clone --recurse-submodules https://github.com/macformula/racecar.git
 
----
+You can now start developing in `racecar`! However, I recommend you configure your IDE with `clangd`, so continue to the next section.
+
+## IDE Integration
+
+_This section is optional but highly recommended._
 
 ### clangd
 
 ??? info "What is `clangd`?"
 
-    [`clangd`](https://clangd.llvm.org/) is our official C/C++ language server. It is __not required__ but will make your development experience much nicer. We have configured CMake to export your most recent compilation's build commands meaning you don't need to manually configure include paths or compiler flags for each project.
+    [`clangd`](https://clangd.llvm.org/) is a C++ language server that provides intelligent code completion and errors by analyzing compiler commands C/C++ language server. We have configured CMake to export your most recent compilation's build commands meaning you don't need to manually configure include paths or compiler flags for each project.
 
     Whenever you build a project with the Makefile, `clangd` will see the new `build/compile_commands.json` and immediately update your IDE's include paths. When you switch which project or platform you are developing for, simply rebuild the project and your development environment will be automatically prepared.
 
-__Version__ 16.0.2
+Download and unzip `clangd-{OS}-16.0.2.zip` from <https://github.com/clangd/clangd/releases?q=16.0.2> under "Assets."
 
-> We hope to update this version soon. See [Issue 93](https://github.com/macformula/racecar/issues/93).
-
-Download `clangd-{OS}-16.0.2.zip` from <https://github.com/clangd/clangd/releases?q=16.0.2> and unzip.
-
-The executable does __not__ need to be on your PATH. Place the binary somewhere convenient and reference it in your IDE (see [IDE Setup](#ide-setup)).
+Place the executable somewhere on your PATH. Follow [these instructions](https://clangd.llvm.org/installation#editor-plugins) to connect it to your IDE.
 
 __Important:__ Create an empty file named `.clangd` in the `firmware/` directory. This file indicates the "root" directory of the project, so it will look for `compile_commands.json` in `firmware/build`.
 
@@ -169,9 +183,14 @@ __Important:__ Create an empty file named `.clangd` in the `firmware/` directory
             Add: --target=arm64-apple-darwin22.6.0
         ```
 
+        
+## Additional Dependencies
+
 ### gRPC
 
 !!! warning "Optional Dependency"
+
+    _You probably don't need this._
 
     Within the racecar repo, gRPC is only used by the SIL Client under `firmware/validation/sil/`. The client is used by the Raspberry Pi MCAL to interact with the [HIL / SIL](https://github.com/macformula/hil).
 
@@ -180,23 +199,3 @@ __Important:__ Create an empty file named `.clangd` in the `firmware/` directory
 You will need a Unix development environment (Unix machine, WSL, or remote into the Raspberry Pi).
 
 Go through the [gRPC C++ Quickstart Guide](https://grpc.io/docs/languages/cpp/quickstart/). Build the example project.
-
-## IDE Setup
-
-_If you use a different IDE, consider [adding instructions](../tutorials/site-dev.md) for setting it up!_
-
-=== ":material-microsoft-visual-studio-code: VS Code"
-
-    __`clangd` Setup__
-
-    1. If you have the [Microsoft C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools), disable it for the `racecar` workspace.
-
-        > Open the Extensions pane with ++ctrl+shift+x++, right click on the C/C++ extension and select `Disable (Workspace)`.
-   
-    1. Install the [`clangd` extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) from LLVM.   
-
-    1. Provide the `clangd` extension settings with the path to the `clangd` executable installed [earlier](#clangd).
-
-        1. Select the `clangd` extension and open :octicons-gear-24: Extension Settings.
-        
-        1. Paste the full `clangd` executable path in the "Clangd: Path" setting.

--- a/docs/docs/firmware/dev-setup.md
+++ b/docs/docs/firmware/dev-setup.md
@@ -2,113 +2,130 @@
 
 Follow these steps to begin developing in `racecar/firmware`.
 
-## Clone the Repository
+!!! tip
+    You can copy a command by clicking the :material-content-copy: icon
 
-Navigate to the directory where you would like to hold the `racecar` repo (I used `C:\Formula\repos`). Run
-
-    git clone https://github.com/macformula/racecar.git
-
-Change in the new `racecar` directory and initialize all submodules with
-
-    git submodule update --init --recursive
+        echo "Copy Me --->"
 
 ## Dependencies
 
-Unless otherwise mentioned, all programs must be accessible on your [PATH](https://en.wikipedia.org/wiki/PATH_(variable)).
-
-The Windows instructions assume that you have installed [Chocolatey](https://chocolatey.org/install).
-
-### GNU Make
-
-__Version__ 4.0 or newer
-
 === "Windows"
 
-        choco install make
+    1. We will use Chocolatey to install most dependencies. Go to <https://chocolatey.org/install#individual> and follow the instructions under "Install Chocolatey for Individual Use".
+
+        Open a Command Prompt __as administrator__ and run
+
+        ```text
+        choco upgrade git msys2 make cmake -y
+        ```
+        
+    2. Install the newest version of Python from <https://www.python.org/downloads/>. When installing, ensure `Add python.exe to PATH` is checked.
+
+    3. Open an MSYS2 terminal by searching `msys2` in the Start Menu :material-microsoft-windows:. Install the GNU toolchain with
+
+        ```bash
+        pacman -S --needed base-devel mingw-w64-ucrt-x86_64-toolchain
+        ```
+
+        Press ++enter++ when prompted to "Enter a selection."
+
+        Add the MSYS2 ucrt64 binary directory to your PATH. You can find this path by searching `msys2` in the Start menu, clicking "Open File Location" then following `ucrt64/bin`.
+
+    4. Install the Arm GNU Toolchain from <https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads>.
+        
+        1. Download the `.exe` installer under "Windows hosted cross toolchains -> AArch32 bare-metal target (arm-none-eabi)".
+        2. Run the installer.
+        3. After the installer finishes, check `Add path to environment variable.`
 
 === "Linux"
 
-        sudo apt-get install build-essential
+    1. Set up the Kitware APT repository <https://apt.kitware.com/>.
 
-!!! tip "Verification"
+        > This allows `apt` to find new versions of CMake.
 
-        make --version
+    2. In your terminal, run
 
----
+        ```bash
+        sudo apt-get update
+        sudo apt-get install software-properties-common
+        sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo apt-get update
+        sudo apt-get install git-all build-essential cmake python3.12 wget
+        ```
 
-### CMake
+    3. Install the Arm GNU Toolchain.
 
-__Version__ 3.27 or newer
+        1. Download and unzip the x86_64 Linux arm-none-eabi toolchain binaries.
 
-=== "Windows"
+                wget https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
+                sudo tar xf arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz -C /usr/share
+                rm arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
 
-        choco install cmake
+        2. Add the binaries to your profile PATH.
 
-=== "Linux"
+            Open `~/.profile` in a text editor and add this to the end of the file.
 
-        sudo apt-get install cmake
+                PATH="/usr/share/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi/bin:$PATH"
 
-    > If this installs an old version (as it did for my Ubuntu 20.04 LTS), you may need to follow the steps at <https://apt.kitware.com/> to use the APT repository hosted by the developers of CMake.
+### Verify Installation
 
-!!! tip "Verification"
+Check that all programs were installed and have an acceptable version.
 
-        cmake --version
+_Do not copy the `# version comments`_
 
----
+```{.bash .no-copy}
+python --version  # >= 3.10, use python3 on Linux / Mac
+make --version    # >= 4.0
+cmake --version   # >= 3.27
+g++ --version     # >= 10
+arm-none-eabi-g++ --version     # >= 13.0
+```
 
-### Arm GNU Toolchain
+## Install STM32 Tools
 
-__Version__ 13.2.rel1 or newer
+### Create an ST Account
 
-Download from <https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads>.
-
-Choose an installer from the "AArch32 bare-metal target (arm-none-eabi)" section. Ensure the executables are available on your PATH.  
-
-!!! tip "Verification"
-
-        arm-none-eabi-gcc --version
-
----
+Go to [www.st.com](https://www.st.com), click on the account :material-account: icon in the top right and create an account. You will need this username and password later on.
 
 ### STM32CubeMX
 
-__Version__ 6.12.0
+CubeMX is a program which generates configuration code for our microcontrollers.
 
-!!! warning
+1. Download version 6.12.0 from <https://www.st.com/en/development-tools/stm32cubemx.html> and install it. You may need to sign in with your ST account.
 
-    You must install this version __exactly__ (not even 6.12.1). Using a different version will cause issues when opening files.
+    !!! warning
 
-Download from <https://www.st.com/en/development-tools/stm32cubemx.html#st-get-software>.
+        You must install this version __exactly__ (not even 6.12.1). Using a different version will cause issues when opening files.
 
-!!! tip "Verification"
+2. Open the install path which contains the `STM32CubeMX` executable and `jre/` directory. Add this directory to your PATH.
 
-    Running `stm32cubemx` should open the program.
+3. Open a terminal in that directory and run CubeMX in "interactive" mode to login.
 
----
+    === "Windows"
 
-### Java Runtime Environment
+            jre\bin\java -jar STM32CubeMX.exe -i
 
-__Version__ 17 or newer
+    === "Linux"
 
-=== "Windows"
+            jre/bin/java -jar STM32CubeMX -i
 
-    No installation needed as it comes with CubeMX.
+4. Wait for the program to stop printing to your terminal. Press ++question+enter++ to display the `MX>` prompt. Login with your `username` and `password`.
 
-=== "Linux"
+        MX> login username password y
 
-        sudo apt install openjdk-17-jre-headless
-
-> [Issue 142](https://github.com/macformula/racecar/issues/142) may remove this dependency.
-
----
+    Do not omit the `y` at the end! You can close CubeMX now.
 
 ### STM32CubeProgrammer
 
-__Version__ 2.16.0 or newer
-
-Download from <https://www.st.com/en/development-tools/stm32cubeprog.html>.
+Download and install version 2.16 or newer from <https://www.st.com/en/development-tools/stm32cubeprog.html>.
 
 It does not need to be on your PATH.
+
+## Clone the Repository
+
+Navigate to a directory where you would like to hold the `racecar` repo (I used `C:\Formula\repos`). Run
+
+    git clone --recurse-submodules https://github.com/macformula/racecar.git
 
 ---
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,6 +90,7 @@ markdown_extensions:
         - includes/abbreviations.md
       base_path:
         - !relative  # Relative to current.md
+        - .          # Relative to this file
 
 repo_url: https://github.com/macformula/racecar
 repo_name: macformula/racecar

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -1,15 +1,14 @@
 ifeq ($(OS),Windows_NT)
 # Convert windows backslash to regular slash
 	CUBEMX_PATH := $(subst \,/,$(shell where STM32CubeMX))
-# Compute the CubeMX's java path. Spaces in path are escaped.
-	space := $(subst ,, )
-	JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java
-# Known bug: Expanding JAVA twice does not work.
 else # Linux / MacOS
     CUBEMX_PATH := $(shell which STM32CubeMX)
-	JAVA := $(shell which java)
-# See https://github.com/macformula/racecar/issues/142
 endif
+
+# Find the JAVA which is installed with CubeMX. Spaces in path are escaped.
+space := $(subst ,, )
+CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java
+# Known bug: Expanding CUBEMX_JAVA twice does not work.
 
 IOC_FILE = board_config.ioc
 
@@ -36,4 +35,4 @@ Makefile: $(IOC_FILE)
 	@printf 'exit\n' >> $(CUBEMX_GEN_SCRIPT)
 
 # Run the cubemx program to generate code.
-	$(JAVA) -jar "$(CUBEMX_PATH)" -q "$(CUBEMX_GEN_SCRIPT)"
+	$(CUBEMX_JAVA) -jar "$(CUBEMX_PATH)" -q "$(CUBEMX_GEN_SCRIPT)"


### PR DESCRIPTION
Restructure the dev setup page to be easier to follow. Remove the JRE section - closes https://github.com/macformula/racecar/issues/142. Add instructions for first use of CubeMx - closes https://github.com/macformula/racecar/issues/152. Links to LLVM docs for clangd integration - resolves https://github.com/macformula/racecar/issues/141