### PR TITLE
STM32Cube Java Path on MacOS Incorrectly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .DS_STORE
 .vscode
+
+**/env
+**/venv
+**/.env
+**/.venv

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -1,4 +1,7 @@
 **/build/
 /.clangd
 /.cache
+/.env
+/.venv
+/venv
 *.log

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -1,7 +1,4 @@
 **/build/
 /.clangd
 /.cache
-/.env
-/.venv
-/venv
 *.log

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -1,9 +1,20 @@
+# Find the STM32CubeMX executable
+ifeq ($(OS),Windows_NT)
+# Convert windows backslash to regular slash
+	CUBEMX_PATH := $(subst \,/,$(shell where STM32CubeMX))
+else
+# Linux / MacOS
+    CUBEMX_PATH := $(shell which STM32CubeMX)
+endif
+
+# Find the JAVA which is installed with CubeMX. Spaces in path are escaped.
 space := $(subst ,, )
-CUBEMX_PATH := $(shell which STM32CubeMX)
 
 ifeq ($(shell uname), Darwin)
+# MacOS
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/Contents/Home/bin/java
 else
+# Windows/Linux
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java
 endif
 

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -1,9 +1,8 @@
 # Find the STM32CubeMX executable
-ifeq ($(OS),Windows_NT)
-# Convert windows backslash to regular slash
+ifeq ($(OS), Windows_NT)
+# Convert Windows backslash to regular slash
 	CUBEMX_PATH := $(subst \,/,$(shell where STM32CubeMX))
-else
-# Linux / MacOS
+else # Linux / MacOS
     CUBEMX_PATH := $(shell which STM32CubeMX)
 endif
 

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -1,8 +1,7 @@
 space := $(subst ,, )
 CUBEMX_PATH := $(shell which STM32CubeMX)
-OS := $(shell uname -s)
 
-ifeq ($(OS), Darwin)
+ifeq ($(shell uname -s), Darwin)
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/Contents/Home/bin/java
 else
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -1,7 +1,7 @@
 space := $(subst ,, )
 CUBEMX_PATH := $(shell which STM32CubeMX)
 
-ifeq ($(shell uname -s), Darwin)
+ifeq ($(shell uname), Darwin)
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/Contents/Home/bin/java
 else
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -1,13 +1,18 @@
+space := $(subst ,, )
+
 ifeq ($(OS),Windows_NT)
 # Convert windows backslash to regular slash
 	CUBEMX_PATH := $(subst \,/,$(shell where STM32CubeMX))
+	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java
 else # Linux / MacOS
     CUBEMX_PATH := $(shell which STM32CubeMX)
+	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/Contents/Home/bin/java
 endif
 
-# Find the JAVA which is installed with CubeMX. Spaces in path are escaped.
-space := $(subst ,, )
-CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java
+all:
+	@echo "CubeMX path: $(CUBEMX_PATH)"
+	@echo "CubeMX Java path: $(CUBEMX_JAVA)"
+
 # Known bug: Expanding CUBEMX_JAVA twice does not work.
 
 IOC_FILE = board_config.ioc

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -13,7 +13,7 @@ ifeq ($(shell uname), Darwin)
 # MacOS
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/Contents/Home/bin/java
 else
-# Windows/Linux
+# Windows / Linux
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java
 endif
 

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -9,10 +9,6 @@ else # Linux / MacOS
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/Contents/Home/bin/java
 endif
 
-all:
-	@echo "CubeMX path: $(CUBEMX_PATH)"
-	@echo "CubeMX Java path: $(CUBEMX_JAVA)"
-
 # Known bug: Expanding CUBEMX_JAVA twice does not work.
 
 IOC_FILE = board_config.ioc

--- a/firmware/cmake/generate_cubemx.mk
+++ b/firmware/cmake/generate_cubemx.mk
@@ -1,12 +1,11 @@
 space := $(subst ,, )
+CUBEMX_PATH := $(shell which STM32CubeMX)
+OS := $(shell uname -s)
 
-ifeq ($(OS),Windows_NT)
-# Convert windows backslash to regular slash
-	CUBEMX_PATH := $(subst \,/,$(shell where STM32CubeMX))
-	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java
-else # Linux / MacOS
-    CUBEMX_PATH := $(shell which STM32CubeMX)
+ifeq ($(OS), Darwin)
 	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/Contents/Home/bin/java
+else
+	CUBEMX_JAVA := $(dir $(subst $(space),\$(space),$(CUBEMX_PATH)))jre/bin/java
 endif
 
 # Known bug: Expanding CUBEMX_JAVA twice does not work.


### PR DESCRIPTION
Closes #246 

@BlakeFreer to verify build commands work on Windows.

`make PROJECT=Demo/Blink PLATFORM=cli build`
`make PROJECT=Demo/Blink PLATFORM=stm32f767 build`

Notes:
- Java path for MacOS assumes STM software was installed to the default location
- Possible issues if STM installation paths are different across Linux and Intel/Silicon Macs (will update in future if required)