### PR TITLE
Controls: TC Scale Factor

### DIFF
--- a/firmware/shared/controls/tc_scale_factor.h
+++ b/firmware/shared/controls/tc_scale_factor.h
@@ -16,19 +16,14 @@ T CalculateActualSlip(T left_rear_wheel_speed, T right_rear_wheel_speed,
     }
 
     if (actual_slip < 0) {
-        return 0;
+        actual_slip = 0;
     }
     return actual_slip;
 }
 
 template <typename T>
-T TCStateflowChart(T actual_slip, T target_slip) {
+T CalculateTCScaleFactor(T actual_slip, T target_slip) {
     // Stateflow: Multi-Stage TC
     return 0;
-}
-
-template <typename T>
-T CalculateTCScaleFactor(T TC_scale_factor_chart_out) {
-    return TC_scale_factor_chart_out;
 }
 }  // namespace ctrl

--- a/firmware/shared/controls/tc_scale_factor_test.cc
+++ b/firmware/shared/controls/tc_scale_factor_test.cc
@@ -27,16 +27,10 @@ int main() {
 
     // (Unbounded) Should return 0 because stateflow functionality is not
     // introduced yet, so function returns 0.
-    ASSERT_CLOSE(ctrl::TCStateflowChart(0.0042, 0.2), 0);
+    ASSERT_CLOSE(ctrl::CalculateTCScaleFactor(0.0042, 0.2), 0);
 
     // (Bounded by 0) Same as previous test
-    ASSERT_CLOSE(ctrl::TCStateflowChart(0.0, 0.2), 0);
-
-    // Should return the output value from the TC Stateflow Chart function
-    ASSERT_CLOSE(ctrl::CalculateTCScaleFactor(0.5), 0.5);
-
-    // Should return the output value from the TC Stateflow Chart function
-    ASSERT_EQ(ctrl::CalculateTCScaleFactor(3), 3);
+    ASSERT_CLOSE(ctrl::CalculateTCScaleFactor(0.0, 0.2), 0);
 
     // This statement will not be reached if an assert fails.
     std::cout << "All tests passed" << std::endl;


### PR DESCRIPTION
Created the function and test file for p_tcScaleFactor:
- Important to note that the Stateflow placeholder function is currently set to return 0 until functionality is figured out.
- The CalculateActualSlip function has potential "Div by Zero" error if both front wheel speeds are 0.
- Please feel free to let me know whether naming conventions should be fixed for clarity.