### PR TITLE
TMS Fan Speed control

### DIFF
--- a/firmware/projects/TMS/main.cc
+++ b/firmware/projects/TMS/main.cc
@@ -94,8 +94,8 @@ const shared::util::CompositeMap<float> volt_stm_to_degC{
 
 /// Spin the fan faster when the acculumator is hotter.
 const float fan_lut_data[][2] = {
-    {-1, 0},
-    {0, 30},
+    {19, 0},
+    {20, 30},
     {50, 100},
 };
 


### PR DESCRIPTION
* Updated TMS fan to activate at 20 degC or higher

Closing #317. Set new points in the fan lut so that power is at 30 when temp is 20 and power is 0 for temp 19.

Can increase its accuracy by adding a decimal point shown below, originally no decimal point so I did not add it in this PR.
```cpp
const float fan_lut_data[][2] = {
    {19.9, 0}, // 19.9 instead of 19
    {20, 30},
    {50, 100},
};
```