### PR TITLE
Add glightbox. Fix indenting in mkdocs.yml

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -42,40 +42,43 @@ extra_javascript:
 copyright: Copyright &copy; McMaster Formula Electric
 
 plugins:
-- search
-- gen-files:
-    scripts:
-      - docs/tutorials/index_gen.py
-      - includes/gen_glossary.py
-- spellcheck:
-    backends:  # the backends you want to use
-    - symspellpy  # as strings
-    - codespell:  # or nested configs
-        dictionaries: [clear]
+  - search
+  - gen-files:
+      scripts:
+          - docs/tutorials/index_gen.py
+          - includes/gen_glossary.py
+  - spellcheck:
+      backends:  # the backends you want to use
+      - symspellpy  # as strings
+      - codespell:  # or nested configs
+          dictionaries: [clear]
 
-    # known_words can also be a list of words
-    known_words: ../includes/known_words.txt
+      # known_words can also be a list of words
+      known_words: ../includes/known_words.txt
 
-    # ignore words in <code> tags
-    ignore_code: yes
+      # ignore words in <code> tags
+      ignore_code: yes
 
-    # minimum length of words to consider
-    min_length: 2
+      # minimum length of words to consider
+      min_length: 2
 
-    # maximum number of capital letters in a word
-    max_capital: 1
+      # maximum number of capital letters in a word
+      max_capital: 1
 
-    # keep unicode characters
-    allow_unicode: no
+      # keep unicode characters
+      allow_unicode: no
 
-    # skip files entirely (supports Unix shell-style wildcards)
-    skip_files:
-    - credits.md
-    - coverage.md
-    - reference/* 
+      # skip files entirely (supports Unix shell-style wildcards)
+      skip_files:
+      - credits.md
+      - coverage.md
+      - reference/* 
 
-    # whether to only check in strict mode
-    strict_only: yes
+      # whether to only check in strict mode
+      strict_only: yes
+  - glightbox:
+      effect: none
+      slide_effect: none
 
 markdown_extensions:
   - admonition

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,5 @@ mkdocs-gen-files
 mkdocs-spellcheck[all]
 mkdocs-macros-plugin
 pymdown-extensions>=10.11.1
+mkdocs-glightbox
 Jinja2


### PR DESCRIPTION
`glightbox` is configured without any animations. This means the images appear and transition instantly instead of fading or sliding in. I think the snappy behaviour is better for a documentation source since the reader is trying to get information as fast as possible.

The old indenting was valid YAML but was inconsistent with the rest of the document.

