### PR TITLE
Templates LookupTable type. Adds LUT to Demo/Mapper

### DIFF
--- a/firmware/projects/Demo/Mapper/main.cc
+++ b/firmware/projects/Demo/Mapper/main.cc
@@ -1,10 +1,12 @@
 /// @author Blake Freer
 /// @date 2024-01-22
 
+#include <format>
 #include <iostream>  // for demo only, will not work on other platforms
 
 #include "shared/util/mappers/clamper.hpp"
 #include "shared/util/mappers/linear_map.hpp"
+#include "shared/util/mappers/lookup_table.hpp"
 #include "shared/util/mappers/mapper.hpp"
 
 using namespace shared::util;  // for demo only
@@ -15,15 +17,28 @@ Clamper<float> zero_to_ten{5, 10};
 CompositeMap comp1{zero_to_ten, double_plus_one};
 CompositeMap comp2{double_plus_one, comp1};
 
+// Lookup table example
+const float lut_data[][2]{
+    {0.f, 0.f},
+    {5.f, 2.f},
+    {8.f, 4.f},
+};
+constexpr int lut_length = (sizeof(lut_data)) / (sizeof(lut_data[0]));
+LookupTable<lut_length, float> lut{lut_data};
+
 int main(void) {
     for (float i = 0; i < 7; i += 0.7) {
-        float v1 = double_plus_one.Evaluate(i);
-        float v2 = comp1.Evaluate(i);
-        float v3 = comp2.Evaluate(i);
-
-        std::cout << i << " (x2 + 1) " << v1 << " (clamp) " << v2
-                  << " (x2 + 1) " << v3 << std::endl;
+        std::cout
+            << std::format(
+                   "{:.1f} (x2 + 1) {:.1f} (clamp) {:.1f} (x2 + 1) {:.1f}", i,
+                   double_plus_one.Evaluate(i), comp1.Evaluate(i),
+                   comp2.Evaluate(i))
+            << std::endl;
     }
 
+    for (float f = 0; f <= 10; f += 1.f) {
+        std::cout << std::format("{:.2f} -> LUT -> {:.2f}", f, lut.Evaluate(f))
+                  << std::endl;
+    }
     return 0;
 }

--- a/firmware/shared/util/mappers/lookup_table.hpp
+++ b/firmware/shared/util/mappers/lookup_table.hpp
@@ -1,36 +1,27 @@
 /// @author Blake Freer
 /// @date 2023-12-04
 
-/**
- * @todo (BlakeFreer) This lookup table requires the keys to be sorted in
- * increasing order. Write a compile time checker that fails if this is not the
- * case (iterate over) keys, if one is less than previous, raise error.
- */
-
 #pragma once
 
 #include "mapper.hpp"
 
 namespace shared::util {
 
-/**
- * @brief Linearly interpolates the input value according to a table to forma
- * piecewise lineary approximation of a function.
- * @tparam row_count_ The number of rows in the lookup table. Must be a compile
- * time constant.
- * @note If the input `key` is less than the lowest key in the table, the the
- * value of the lowest key is returned, and similarly for the largest key.
- */
-template <int row_count_>
-class LookupTable : public Mapper<float> {
+/// @brief Linearly interpolates the input value according to a table to form a
+/// piecewise lineary approximation of a function.
+/// @tparam row_count_ The number of rows in the lookup table. Must be a compile
+/// time constant.
+/// @note If the input `key` is less than the lowest key in the table, the the
+/// value of the lowest key is returned, and similarly for the largest key.
+template <int row_count_, typename T = float>
+    requires std::is_floating_point_v<T>
+class LookupTable : public Mapper<T> {
 public:
-    /**
-     * @warning The table's first columns (keys) must be sorted in increasing
-     * order.
-     */
-    LookupTable(float const (*table)[2]) : table_(table) {}
+    /// @warning The table's first columns (keys) must be sorted in increasing
+    /// order.
+    LookupTable(T const (*table)[2]) : table_(table) {}
 
-    inline float Evaluate(float key) const override {
+    inline T Evaluate(T key) const override {
         int least_greater_idx = 0;
 
         // Find next greatest element in keys_, assumes keys_ is sorted
@@ -47,19 +38,16 @@ public:
             return table_[row_count_ - 1][1];
         }
 
-        float fraction =
-            (key - table_[least_greater_idx - 1][0]) /
-            (table_[least_greater_idx][0] - table_[least_greater_idx - 1][0]);
+        auto [prev_key, prev_val] = table_[least_greater_idx - 1];
+        auto [next_key, next_val] = table_[least_greater_idx];
 
-        float interpolated_value =
-            (1 - fraction) * table_[least_greater_idx - 1][1] +
-            fraction * table_[least_greater_idx][1];
+        T fraction = (key - prev_key) / (next_key - prev_key);
 
-        return interpolated_value;
+        return (1 - fraction) * prev_val + fraction * next_val;
     }
 
 private:
-    const float (*table_)[2];
+    const T (*table_)[2];
 };
 
 }  // namespace shared::util


### PR DESCRIPTION
Improves the LookupTable by

- Allowing it to be a `float` or `double` using the `requires is_floating` clause [[diff]](https://github.com/macformula/racecar/pull/364/files#diff-ecc078c566085b5baf22d8304933b48d024d547b023856ed6c070fc97e9a04adR17)
- Adding temporary `prev_val, next_key` etc variables to improve readability [[diff]](https://github.com/macformula/racecar/pull/364/files#diff-ecc078c566085b5baf22d8304933b48d024d547b023856ed6c070fc97e9a04adR41)
- Replacing `/* */` comments with `///`. We will gradually change this elsewhere
- Adding a sample usage to the Demo/Mapper project [[diff]](https://github.com/macformula/racecar/pull/364/files#diff-2f6906da9720b2962c330219ea5189d77d551e7b418373ac2cc3b721ddffb3ee)

@jabrap1 