### PR TITLE
Improve Mappers

### DIFF
--- a/firmware/projects/Demo/Mapper/CMakeLists.txt
+++ b/firmware/projects/Demo/Mapper/CMakeLists.txt
@@ -1,10 +1,1 @@
-# Blake Freer
-# January 6, 2023
-
-# The target executable 'main' is created in the master CMakeLists. Do not change its name.
-# We only need to add the source code files and include directories.
-
 target_sources(main PRIVATE main.cc)
-
-# Notice that we don't include any mcal/ subdirectory in this CMake file.
-# The master CMakeLists handles platform selection and library linking.

--- a/firmware/projects/Demo/Mapper/README.md
+++ b/firmware/projects/Demo/Mapper/README.md
@@ -1,3 +1,12 @@
-# DemoMapper
+# Demo/Mapper
 
-This shows off the mapping concept by creating a linear map, clamper, and composing them
+Examples from [shared/util/mappers/README.md](../../../shared/util/mappers/README.md). See that file for more details.
+
+## Usage
+
+This project only supports the `cli` platform.
+
+```bash
+make PROJECT=Demo/Mapper PLATFORM=cli
+./build/Demo/Mapper/cli/main
+```

--- a/firmware/projects/Demo/Mapper/main.cc
+++ b/firmware/projects/Demo/Mapper/main.cc
@@ -14,8 +14,8 @@ using namespace shared::util;  // for demo only
 LinearMap<float> double_plus_one{2, 1.0f};
 Clamper<float> zero_to_ten{5, 10};
 
-CompositeMap comp1{zero_to_ten, double_plus_one};
-CompositeMap comp2{double_plus_one, comp1};
+CompositeMap comp1{double_plus_one, zero_to_ten};
+CompositeMap comp2{comp1, double_plus_one};
 
 // Lookup table example
 const float lut_data[][2]{

--- a/firmware/projects/Demo/Mapper/main.cc
+++ b/firmware/projects/Demo/Mapper/main.cc
@@ -1,44 +1,89 @@
 /// @author Blake Freer
-/// @date 2024-01-22
+/// @date 2024-12-28
 
 #include <format>
 #include <iostream>  // for demo only, will not work on other platforms
 
 #include "shared/util/mappers/clamper.hpp"
+#include "shared/util/mappers/constant.hpp"
+#include "shared/util/mappers/identity.hpp"
 #include "shared/util/mappers/linear_map.hpp"
 #include "shared/util/mappers/lookup_table.hpp"
 #include "shared/util/mappers/mapper.hpp"
+#include "shared/util/mappers/quadratic_map.hpp"
 
-using namespace shared::util;  // for demo only
-
-LinearMap<float> double_plus_one{2, 1.0f};
-Clamper<float> zero_to_ten{5, 10};
-
-CompositeMap comp1{double_plus_one, zero_to_ten};
-CompositeMap comp2{comp1, double_plus_one};
-
-// Lookup table example
-const float lut_data[][2]{
-    {0.f, 0.f},
-    {5.f, 2.f},
-    {8.f, 4.f},
-};
-constexpr int lut_length = (sizeof(lut_data)) / (sizeof(lut_data[0]));
-LookupTable<lut_length, float> lut{lut_data};
+void expect_eq(double actual, double expected) {
+    std::cout << std::format("Expected {:.2f}, got: {:.2f}", expected, actual);
+    if (std::abs(expected - actual) > 0.01) {
+        std::cout << "  FAIL";
+    }
+    std::cout << std::endl;
+}
 
 int main(void) {
-    for (float i = 0; i < 7; i += 0.7) {
-        std::cout
-            << std::format(
-                   "{:.1f} (x2 + 1) {:.1f} (clamp) {:.1f} (x2 + 1) {:.1f}", i,
-                   double_plus_one.Evaluate(i), comp1.Evaluate(i),
-                   comp2.Evaluate(i))
-            << std::endl;
+    {
+        std::cout << "Linear Map" << std::endl;
+        shared::util::LinearMap<double> f{10., 3.};
+        expect_eq(f.Evaluate(7), 73);
     }
 
-    for (float f = 0; f <= 10; f += 1.f) {
-        std::cout << std::format("{:.2f} -> LUT -> {:.2f}", f, lut.Evaluate(f))
-                  << std::endl;
+    {
+        std::cout << "Quadratic Map" << std::endl;
+        shared::util::QuadraticMap<double> f{1., 0., 5.};
+        expect_eq(f.Evaluate(0.), 5);
+        expect_eq(f.Evaluate(1.), 6);
+        expect_eq(f.Evaluate(2.), 9);
     }
+
+    {
+        std::cout << "Clamper" << std::endl;
+        shared::util::Clamper<double> f{0., 10.};
+        expect_eq(f.Evaluate(-10.), 0);
+        expect_eq(f.Evaluate(3.), 3);
+        expect_eq(f.Evaluate(100.), 10);
+    }
+
+    {
+        std::cout << "Lookup Table" << std::endl;
+        const double lut_data[][2] = {{-2., 4.}, {-1., 1.}, {0., 0.},
+                                      {1., 1.},  {2., 4.},  {3., 9.}};
+
+        constexpr int lut_length = (sizeof(lut_data)) / (sizeof(lut_data[0]));
+        shared::util::LookupTable<lut_length, double> f{lut_data};
+
+        expect_eq(f.Evaluate(-1.5), 2.5);
+        expect_eq(f.Evaluate(0.5), 0.5);
+        expect_eq(f.Evaluate(2.), 4);
+        expect_eq(f.Evaluate(4.), 9);   // (above highest key)
+        expect_eq(f.Evaluate(-4.), 4);  // (below lowest key)
+    }
+
+    {
+        std::cout << "Identity" << std::endl;
+        shared::util::IdentityMap<double> f;
+        expect_eq(f.Evaluate(6.), 6);
+    }
+
+    {
+        std::cout << "Constant" << std::endl;
+        shared::util::ConstantMap<double> f{42.};
+        expect_eq(f.Evaluate(0.5), 42);
+        expect_eq(f.Evaluate(10.), 42);
+    }
+
+    {
+        std::cout << "Composite Map" << std::endl;
+
+        shared::util::LinearMap<double> cel_to_fahr{1.8, 32.};
+        shared::util::Clamper<double> limiter{32., 212.};
+
+        shared::util::CompositeMap<double> f{cel_to_fahr, limiter};
+
+        expect_eq(f.Evaluate(20.), 68);    // 20 C = 68 F
+        expect_eq(f.Evaluate(-10.), 32);   // -10 C = 14 F, clamped to 32 F
+        expect_eq(f.Evaluate(100.), 212);  // 100 C = 212 F
+        expect_eq(f.Evaluate(101.), 212);  // 101 C = 213.8 F, clamped to 212 F
+    }
+
     return 0;
 }

--- a/firmware/projects/TMS/main.cc
+++ b/firmware/projects/TMS/main.cc
@@ -86,8 +86,8 @@ const shared::util::LinearMap<float> volt_stm_to_volt_ts{
 /// Compose the two maps to get the final map from the STM voltage to the
 /// temperature in degrees C.
 const shared::util::CompositeMap<float> volt_stm_to_degC{
-    volt_ts_to_degC,      // outer (second) function
-    volt_stm_to_volt_ts,  // inner (first) function
+    volt_stm_to_volt_ts,
+    volt_ts_to_degC,
 };
 
 }  // namespace tempsensor

--- a/firmware/shared/util/mappers/README.md
+++ b/firmware/shared/util/mappers/README.md
@@ -1,0 +1,136 @@
+# Mappers
+
+Utility functions for evaluating and composing math equations.
+
+You can run the sample code with the `Demo/Mapper` project [[link]](../../../projects/Demo/Mapper/README.md).
+
+## The Abstract `Mapper` Class
+
+A `Mapper` subclass can implements a mathematical function by overriding the `Evaluate(x)` method. There are several built-in subclasses.
+
+## `LinearMap`
+
+$f(x)=mx+b$
+
+Parameterized by `(m, b)`.
+
+```c++
+#include "shared/util/mappers/linear_map.hpp"
+
+shared::util::LinearMap<double> f{10., 3.};
+expect_eq(f.Evaluate(7), 73);
+```
+
+## `QuadraticMap`
+
+$f(x)=ax^2+bx+c$
+
+Parameterized by `(a, b, c)`.
+
+```c++
+#include "shared/util/mappers/quadratic_map.hpp"
+
+shared::util::QuadraticMap<double> f{1., 0., 5.};
+expect_eq(f.Evaluate(0.), 5);
+expect_eq(f.Evaluate(1.), 6);
+expect_eq(f.Evaluate(2.), 9);
+```
+
+## `Clamper`
+
+Restrict a value between a lower and upper bound.
+
+Parameterized by `(lower, upper)`.
+
+```c++
+#include "shared/util/mappers/clamper.hpp"
+
+shared::util::Clamper<double> f{0., 10.};
+expect_eq(f.Evaluate(-10.), 0);
+expect_eq(f.Evaluate(3.), 3);
+expect_eq(f.Evaluate(100.), 10);
+```
+
+## `LookupTable`
+
+Evaluate a piecewise function given by an array of key-value pairs.
+
+The input to `Evaluate()` is clamped between the lowest and highest key.
+
+```c++
+#include "shared/util/mappers/lookup_table.hpp"
+
+// Define the lookup table key-values.
+// The keys must be sorted in increasing order.
+// This example approximates x^2 from -2 to +3
+const double lut_data[][2] = {
+    {-2., 4.},
+    {-1., 1.},
+    {0., 0.},
+    {1., 1.},
+    {2., 4.},
+    {3., 9.}
+};
+
+constexpr int lut_length = (sizeof(lut_data)) / (sizeof(lut_data[0]));
+shared::util::LookupTable<lut_length, double> f{lut_data};
+
+expect_eq(f.Evaluate(-1.5), 2.5);
+expect_eq(f.Evaluate(0.5), 0.5);
+expect_eq(f.Evaluate(2.), 4);
+expect_eq(f.Evaluate(4.), 9);   // (above highest key)
+expect_eq(f.Evaluate(-4.), 4);  // (below lowest key)
+```
+
+## `IdentityMap`
+
+$f(x)=x$
+
+No parameters. This class is needed when another class/function expects a `Mapper` as an input, but the desired input to just return the input.
+
+```c++
+#include "shared/util/mappers/identity.hpp"
+
+shared::util::IdentityMap<double> f;
+expect_eq(f.Evaluate(6.), 6);
+```
+
+## `ConstantMap`
+
+$f(x)=c$
+
+Parameterized by `(c)`. Useful as a placeholder.
+
+```c++
+#include "shared/util/mappers/constant.hpp"
+
+shared::util::ConstantMap<double> f{42.};
+expect_eq(f.Evaluate(0.5), 42);
+expect_eq(f.Evaluate(10.), 42);
+```
+
+## `CompositeMap`
+
+$f(x) = h(g(x))$
+
+Parameterized by _mappers_ `(g, h)`. __Note the order:__ inner function is passed first.
+
+Composes two maps. Used when a class/function requires a `Mapper` input but the desired behaviour cannot be expressed with a single `Mapper`, so two must be composed.
+
+For example, to convert Celsius to Fahrenheit, but then clamp the output between 32 degF and 212 degF, you could compose `g(x) = LinearMap` and `h(x)=Clamper`.
+
+```c++
+#include "shared/utils/mappers/mapper.hpp" // Defines CompositeMap
+#include "shared/utils/mappers/linear_map.hpp"
+#include "shared/utils/mappers/clamper.hpp"
+
+shared::util::LinearMap<double> cel_to_fahr{1.8, 32.};
+shared::util::Clamper<double> limiter{32., 212.};
+
+shared::util::CompositeMap<double> f{cel_to_fahr, limiter};
+
+expect_eq(f.Evaluate(20.), 68);    // 20 C = 68 F
+expect_eq(f.Evaluate(-10.), 32);   // -10 C = 14 F, clamped to 32 F
+expect_eq(f.Evaluate(100.), 212);  // 100 C = 212 F
+expect_eq(f.Evaluate(101.), 212);  // 101 C = 213.8 F, clamped to 212 F
+```

--- a/firmware/shared/util/mappers/README.md
+++ b/firmware/shared/util/mappers/README.md
@@ -53,7 +53,7 @@ expect_eq(f.Evaluate(100.), 10);
 
 ## `LookupTable`
 
-Evaluate a piecewise function given by an array of key-value pairs.
+Evaluate a piecewise function given by an array of key-value pairs. Linearly interpolates between values according to the input key.
 
 The input to `Evaluate()` is clamped between the lowest and highest key.
 

--- a/firmware/shared/util/mappers/clamper.hpp
+++ b/firmware/shared/util/mappers/clamper.hpp
@@ -7,13 +7,11 @@
 
 namespace shared::util {
 
-/**
- * @brief Clamps a value between an `upper` and `lower` limit.
- * @tparam T Output type.
- * @tparam U Input type.
- * @note To only clamp from above, pass `std::numeric_limits<T>().minimum()` as
- * `lower`, and `.maximum()` as `upper` for a clamp from below.
- */
+/// @brief Clamps a value between an `upper` and `lower` limit.
+/// @tparam T Output type.
+/// @tparam U Input type.
+/// @note To only clamp from above, pass `std::numeric_limits<T>().minimum()` as
+/// `lower`, and `.maximum()` as `upper` for a clamp from below.
 template <typename T, typename U = T>
 class Clamper : public Mapper<T, U> {
 public:

--- a/firmware/shared/util/mappers/constant.hpp
+++ b/firmware/shared/util/mappers/constant.hpp
@@ -7,7 +7,7 @@
 
 namespace shared::util {
 
-/// @brief Evaluates the constant function `f(x) = c)`.
+/// @brief Evaluates the constant function `f(x) = c`.
 /// @tparam T Output type.
 /// @tparam U Input type.
 /// @note Always evaluates to the same value. Included for completeness.
@@ -16,13 +16,11 @@ class ConstantMap : public Mapper<T, U> {
 public:
     ConstantMap(T c) : c_(c) {}
 
-    static inline T Evaluate(U x, T c) {
-        return c;
-    }
-
     inline T Evaluate(U x) const override {
         return c_;
     }
+
+    // No static `Evaluate()` for obvious reasons
 
 private:
     const T c_;

--- a/firmware/shared/util/mappers/constant.hpp
+++ b/firmware/shared/util/mappers/constant.hpp
@@ -17,6 +17,7 @@ public:
     ConstantMap(T c) : c_(c) {}
 
     inline T Evaluate(U x) const override {
+        (void)x;
         return c_;
     }
 

--- a/firmware/shared/util/mappers/constant.hpp
+++ b/firmware/shared/util/mappers/constant.hpp
@@ -7,12 +7,10 @@
 
 namespace shared::util {
 
-/**
- * @brief Evaluates the constant function `f(x) = c)`.
- * @tparam T Output type.
- * @tparam U Input type.
- * @note Always evaluates to the same value. Included for completeness.
- */
+/// @brief Evaluates the constant function `f(x) = c)`.
+/// @tparam T Output type.
+/// @tparam U Input type.
+/// @note Always evaluates to the same value. Included for completeness.
 template <typename T, typename U = T>
 class ConstantMap : public Mapper<T, U> {
 public:

--- a/firmware/shared/util/mappers/identity.hpp
+++ b/firmware/shared/util/mappers/identity.hpp
@@ -7,13 +7,11 @@
 
 namespace shared::util {
 
-/**
- * @brief The most basic map; that which returns its input. This is added for
- * completeness when a mapper object is required but has no behaviour.
- *
- * @tparam T Output Type
- * @tparam U Input Type, default = `T`
- */
+/// @brief The most basic map; that which returns its input. This is added for
+/// completeness when a mapper object is required but has no behaviour.
+///
+/// @tparam T Output Type
+/// @tparam U Input Type, default = `T`
 template <typename T, typename U = T>
 class IdentityMap : public shared::util::Mapper<T, U> {
 public:

--- a/firmware/shared/util/mappers/linear_map.hpp
+++ b/firmware/shared/util/mappers/linear_map.hpp
@@ -7,11 +7,9 @@
 
 namespace shared::util {
 
-/**
- * @brief Evaluates the linear function `f(x) = mx + b`.
- * @tparam T Ouput type.
- * @tparam U Input type.
- */
+/// @brief Evaluates the linear function `f(x) = mx + b`.
+/// @tparam T Ouput type.
+/// @tparam U Input type.
 template <typename T, typename U = T>
 class LinearMap : public Mapper<T, U> {
 public:

--- a/firmware/shared/util/mappers/lookup_table.hpp
+++ b/firmware/shared/util/mappers/lookup_table.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "mapper.hpp"
 
 namespace shared::util {

--- a/firmware/shared/util/mappers/mapper.hpp
+++ b/firmware/shared/util/mappers/mapper.hpp
@@ -24,25 +24,21 @@ public:
 template <typename Tf, typename Tg = Tf, typename U = Tg>
 class CompositeMap : public Mapper<Tf, U> {
 public:
-    /// @param f Outer function.
     /// @param g Inner function.
+    /// @param f Outer function.
     /// @note Evaulates `f(g(x))`, so `g` is applied before `f`.
-    CompositeMap(const Mapper<Tf, Tg>& f, const Mapper<Tg, U>& g)
-        : f_(f), g_(g) {}
-
-    /// @brief Evaluates `f(g(x))`.
-    static inline Tf Evaluate(Tg x, const Mapper<Tf, Tg>& f,
-                              const Mapper<Tg, U>& g) {
-        return f.Evaluate(g.Evaluate(x));
-    }
+    CompositeMap(const Mapper<Tg, U>& g, const Mapper<Tf, Tg>& f)
+        : g_(g), f_(f) {}
 
     inline Tf Evaluate(U x) const override {
-        return CompositeMap<Tf, Tg, U>::Evaluate(x, f_, g_);
+        return f_.Evaluate(g_.Evaluate(x));
     }
 
+    // No static `Evaluate()` since you should directly compose the functions.
+
 private:
-    const Mapper<Tf, Tg>& f_;
     const Mapper<Tg, U>& g_;
+    const Mapper<Tf, Tg>& f_;
 };
 
 }  // namespace shared::util

--- a/firmware/shared/util/mappers/mapper.hpp
+++ b/firmware/shared/util/mappers/mapper.hpp
@@ -3,16 +3,13 @@
 
 #pragma once
 
-#include <concepts>
-
+#include <type_traits>
 namespace shared::util {
 
-/**
- * @brief Evaluates a function.
- * @tparam T Output type, by default `float`.
- * @tparam U Input type, by default equal to `T`.
- * @note `T` and `U` must be numeric types.
- */
+/// @brief Evaluates a function.
+/// @tparam T Output type, by default `float`.
+/// @tparam U Input type, by default equal to `T`.
+/// @note `T` and `U` must be numeric types.
 template <typename T, typename U = T>
     requires(std::is_arithmetic_v<T>)
 class Mapper {
@@ -20,26 +17,20 @@ public:
     virtual T Evaluate(U x) const = 0;
 };
 
-/**
- * @brief Evaluates composed functions
- * @tparam Tf Output type of `f()`.
- * @tparam Tg Output type of `g()`.
- * @tparam U Input type to `g()`.
- */
+/// @brief Evaluates composed functions
+/// @tparam Tf Output type of `f()`.
+/// @tparam Tg Output type of `g()`.
+/// @tparam U Input type to `g()`.
 template <typename Tf, typename Tg = Tf, typename U = Tg>
 class CompositeMap : public Mapper<Tf, U> {
 public:
-    /**
-     * @param f Outer function.
-     * @param g Inner function.
-     * @note Evaulates `f(g(x))`, so `g` is applied before `f`.
-     */
+    /// @param f Outer function.
+    /// @param g Inner function.
+    /// @note Evaulates `f(g(x))`, so `g` is applied before `f`.
     CompositeMap(const Mapper<Tf, Tg>& f, const Mapper<Tg, U>& g)
         : f_(f), g_(g) {}
 
-    /**
-     * @brief Evaluates `f(g(x))`.
-     */
+    /// @brief Evaluates `f(g(x))`.
     static inline Tf Evaluate(Tg x, const Mapper<Tf, Tg>& f,
                               const Mapper<Tg, U>& g) {
         return f.Evaluate(g.Evaluate(x));

--- a/firmware/shared/util/mappers/quadratic_map.hpp
+++ b/firmware/shared/util/mappers/quadratic_map.hpp
@@ -6,11 +6,9 @@
 #include "mapper.hpp"
 
 namespace shared::util {
-/**
- * @brief Evaluates the quadratic function `f(x) = axx + bx + c`.
- * @tparam T Ouptut type.
- * @tparam U Input type.
- */
+/// @brief Evaluates the quadratic function `f(x) = axx + bx + c`.
+/// @tparam T Ouptut type.
+/// @tparam U Input type.
 template <typename T, typename U = T>
 class QuadraticMap : public Mapper<T, U> {
 public:


### PR DESCRIPTION
Closes #39. Closes #286 

# Changes

- Swaps `/* */` comments for `///` in `shared/util/mappers/*`
- Remove some of the static inline `Evaluate()` methods which provide no benefit. For example, you should never call the static
  `ConstantMap<double>::Evaluate(x, 42)` method since this can only return the constant 42. Note this is distinct from storing a `ConstantMap` in a variable which does have valid uses.
- Reorders the input parameters in `CompositeMap` to be more intuitive. Updates TMS as required.
- Adds a README explaining how to use the Mappers.
- Improves the `Demo/Mapper` project to include all mappers with a more intuitive presentation. Executes and verifies each `Mapper` subclass.