### PR TITLE
User/mfang/silpolymorphism

### DIFF
--- a/firmware/validation/sil/sil_client.cc
+++ b/firmware/validation/sil/sil_client.cc
@@ -167,7 +167,7 @@ bool SilClient::ReadDigitalLevel(std::string ecu_name, std::string sig_name) {
 
     ReadRegister(ecu_name, sig_name, 
         signals::SignalDirection::SIGNAL_DIRECTION_INPUT, 
-        signals::SignalType::SIGNAL_TYPE_ANALOG, &read_response);
+        signals::SignalType::SIGNAL_TYPE_ANALOG, read_response);
 
     return read_response.value_digital().level();
 
@@ -202,7 +202,7 @@ double SilClient::ReadAdcVoltage(std::string ecu_name, std::string sig_name) {
 
     ReadRegister(ecu_name, sig_name, 
         signals::SignalDirection::SIGNAL_DIRECTION_INPUT, 
-        signals::SignalType::SIGNAL_TYPE_ANALOG, &read_response);
+        signals::SignalType::SIGNAL_TYPE_ANALOG, read_response);
 
     if (!read_response.has_value_analog()) {
         std::cout << "expected adc value got: " << read_response.value_case()

--- a/firmware/validation/sil/sil_client.cc
+++ b/firmware/validation/sil/sil_client.cc
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <string>
+#include <format>
 
 #include "signals.grpc.pb.h"
 #include "signals.pb.h"
@@ -23,146 +24,29 @@ void SilClient::Connect() {
 
 void SilClient::RegisterDigitalInput(std::string ecu_name,
                                      std::string sig_name) {
-    // grpc::Status status;
-    // grpc::ClientContext context;
-    // signals::RegisterSignalRequest register_request;
-    // signals::RegisterSignalResponse register_response;
-
-    // register_request.set_ecu_name(ecu_name);
-    // register_request.set_signal_name(sig_name);
-    // register_request.set_signal_direction(
-    //     signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
-    // register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
-
-    // status =
-    //     stub_->RegisterSignal(&context, register_request, &register_response);
-    // if (!status.ok()) {
-    //     std::cout << status.error_code() << ": " << status.error_message()
-    //               << std::endl;
-    // }
-
-    // if (!register_response.status()) {
-    //     std::cout << "register signal error: " << register_response.error()
-    //               << std::endl;
-    // }
-
     RegisterIO(ecu_name, sig_name, 
         signals::SignalDirection::SIGNAL_DIRECTION_INPUT, signals::SignalType::SIGNAL_TYPE_DIGITAL);
 }
 
 void SilClient::RegisterDigitalOutput(std::string ecu_name,
                                       std::string sig_name) {
-    // grpc::Status status;
-    // grpc::ClientContext context;
-    // signals::RegisterSignalRequest register_request;
-    // signals::RegisterSignalResponse register_response;
-
-    // register_request.set_ecu_name(ecu_name);
-    // register_request.set_signal_name(sig_name);
-    // register_request.set_signal_direction(
-    //     signals::SignalDirection::SIGNAL_DIRECTION_OUTPUT);
-    // register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
-
-    // status =
-    //     stub_->RegisterSignal(&context, register_request, &register_response);
-    // if (!status.ok()) {
-    //     std::cout << status.error_code() << ": " << status.error_message()
-    //               << std::endl;
-    // }
-
-    // if (!register_response.status()) {
-    //     std::cout << "register signal error: " << register_response.error()
-    //               << std::endl;
-    // }
-
     RegisterIO(ecu_name, sig_name, 
         signals::SignalDirection::SIGNAL_DIRECTION_OUTPUT, signals::SignalType::SIGNAL_TYPE_DIGITAL);
 }
 
 void SilClient::RegisterAnalogInput(std::string ecu_name,
                                     std::string sig_name) {
-    // grpc::Status status;
-    // grpc::ClientContext context;
-    // signals::RegisterSignalRequest register_request;
-    // signals::RegisterSignalResponse register_response;
-
-    // register_request.set_ecu_name(ecu_name);
-    // register_request.set_signal_name(sig_name);
-    // register_request.set_signal_direction(
-    //     signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
-    // register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_ANALOG);
-
-    // status =
-    //     stub_->RegisterSignal(&context, register_request, &register_response);
-    // if (!status.ok()) {
-    //     std::cout << status.error_code() << ": " << status.error_message()
-    //               << std::endl;
-    // }
-
-    // if (!register_response.status()) {
-    //     std::cout << "register signal error: " << register_response.error()
-    //               << std::endl;
-    // }
-
     RegisterIO(ecu_name, sig_name, 
-        signals::SignalDirection::SIGNAL_DIRECTION_INPUT, signals::SignalType::SIGNAL_TYPE_ANALOG)
+        signals::SignalDirection::SIGNAL_DIRECTION_INPUT, signals::SignalType::SIGNAL_TYPE_ANALOG);
 
 }
 
 void SilClient::SetDigitalLevel(std::string ecu_name, std::string sig_name,
                                 bool level) {
-//     grpc::Status status;
-//     grpc::ClientContext context;
-//     signals::WriteSignalRequest write_request;
-//     signals::WriteSignalResponse write_response;
-
-//     write_request.set_ecu_name(ecu_name);
-//     write_request.set_signal_name(sig_name);
-//     write_request.mutable_value_digital()->set_level(level);
-
-//     status = stub_->WriteSignal(&context, write_request, &write_response);
-//     if (!status.ok()) {
-//         std::cout << status.error_code() << ": " << status.error_message()
-//                   << std::endl;
-//         return;
-//     }
-
-//     if (!write_response.status()) {
-//         std::cout << "write response error: " << write_response.error()
-//                   << std::endl;
-//         return;
-//     }
-
     SetRegister(ecu_name, sig_name, level);
 }
 
 bool SilClient::ReadDigitalLevel(std::string ecu_name, std::string sig_name) {
-    // grpc::Status status;
-    // grpc::ClientContext context;
-    // signals::ReadSignalRequest read_request;
-    // signals::ReadSignalResponse read_response;
-
-    // read_request.set_ecu_name(ecu_name);
-    // read_request.set_signal_name(sig_name);
-    // read_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
-    // read_request.set_signal_direction(
-    //     signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
-
-    // status = stub_->ReadSignal(&context, read_request, &read_response);
-    // if (!status.ok()) {
-    //     std::cout << status.error_code() << ": " << status.error_message()
-    //               << std::endl;
-    //     return false;
-    // }
-
-    // if (!read_response.status()) {
-    //     std::cout << "write response error: " << read_response.error()
-    //               << std::endl;
-    //     return false;
-    // }
-
-    // return read_response.value_digital().level();
-
     signals::ReadSignalResponse read_response;
 
     ReadRegister(ecu_name, sig_name, 
@@ -174,30 +58,6 @@ bool SilClient::ReadDigitalLevel(std::string ecu_name, std::string sig_name) {
 }
 
 double SilClient::ReadAdcVoltage(std::string ecu_name, std::string sig_name) {
-    // grpc::Status status;
-    // grpc::ClientContext context;
-    // signals::ReadSignalRequest read_request;
-    // signals::ReadSignalResponse read_response;
-
-    // read_request.set_ecu_name(ecu_name);
-    // read_request.set_signal_name(sig_name);
-    // read_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_ANALOG);
-    // read_request.set_signal_direction(
-    //     signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
-
-    // status = stub_->ReadSignal(&context, read_request, &read_response);
-    // if (!status.ok()) {
-    //     std::cout << status.error_code() << ": " << status.error_message()
-    //               << std::endl;
-    //     return 0.0;
-    // }
-
-    // if (!read_response.status()) {
-    //     std::cout << "write response error: " << read_response.error()
-    //               << std::endl;
-    //     return 0.0;
-    // }
-
     signals::ReadSignalResponse read_response;
 
     ReadRegister(ecu_name, sig_name, 
@@ -205,14 +65,13 @@ double SilClient::ReadAdcVoltage(std::string ecu_name, std::string sig_name) {
         signals::SignalType::SIGNAL_TYPE_ANALOG, read_response);
 
     if (!read_response.has_value_analog()) {
-        std::cout << "expected adc value got: " << read_response.value_case()
-                  << std::endl;
+        std::cout << std::format("expected adc value got: {}\n", read_response.value_case());
     }
 
     return read_response.value_analog().voltage();
 }
 
-void RegisterIO(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, signals::SignalType sig_type) {
+void SilClient::RegisterIO(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, signals::SignalType sig_type) {
     grpc::Status status;
     grpc::ClientContext context;
     signals::RegisterSignalRequest register_request;
@@ -226,17 +85,15 @@ void RegisterIO(std::string ecu_name, std::string sig_name, signals::SignalDirec
     status =
         stub_->RegisterSignal(&context, register_request, &register_response);
     if (!status.ok()) {
-        std::cout << status.error_code() << ": " << status.error_message()
-                  << std::endl;
+        std::cout << std::format("{} : {}\n", status.error_code(), status.error_message());
     }
 
     if (!register_response.status()) {
-        std::cout << "register signal error: " << register_response.error()
-                  << std::endl;
+        std::cout << std::format("register signal error: {}\n", register_response.error());
     }
 }
 
-void SetRegister(std::string ecu_name, std::string sig_name, bool level) {
+void SilClient::SetRegister(std::string ecu_name, std::string sig_name, bool level) {
     grpc::Status status;
     grpc::ClientContext context;
     signals::WriteSignalRequest write_request;
@@ -248,19 +105,18 @@ void SetRegister(std::string ecu_name, std::string sig_name, bool level) {
 
     status = stub_->WriteSignal(&context, write_request, &write_response);
     if (!status.ok()) {
-        std::cout << status.error_code() << ": " << status.error_message()
-                  << std::endl;
+        std::cout << std::format("{} : {}\n", status.error_code(), status.error_message());
         return;
     }
 
     if (!write_response.status()) {
-        std::cout << "write response error: " << write_response.error()
-                  << std::endl;
+        std::cout << std::format("write response error: {}\n", write_response.error());
+
         return;
     }
 }
 
-void ReadRegister(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, 
+void SilClient::ReadRegister(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, 
     signals::SignalType sig_type, signals::ReadSignalResponse &read_response) {
 
     grpc::Status status;
@@ -274,15 +130,15 @@ void ReadRegister(std::string ecu_name, std::string sig_name, signals::SignalDir
 
     status = stub_->ReadSignal(&context, read_request, read_response);
     if (!status.ok()) {
-        std::cout << status.error_code() << ": " << status.error_message()
-                  << std::endl;
-        return 0.0;
+        std::cout << std::format("{} : {}\n", status.error_code(), status.error_message());
+
+        return;
     }
 
     if (!read_response.status()) {
-        std::cout << "write response error: " << read_response->error()
+        std::cout << "write response error: " << read_response.error()
                   << std::endl;
-        return 0.0;
+        return;
     }
 
 }

--- a/firmware/validation/sil/sil_client.cc
+++ b/firmware/validation/sil/sil_client.cc
@@ -23,58 +23,196 @@ void SilClient::Connect() {
 
 void SilClient::RegisterDigitalInput(std::string ecu_name,
                                      std::string sig_name) {
-    grpc::Status status;
-    grpc::ClientContext context;
-    signals::RegisterSignalRequest register_request;
-    signals::RegisterSignalResponse register_response;
+    // grpc::Status status;
+    // grpc::ClientContext context;
+    // signals::RegisterSignalRequest register_request;
+    // signals::RegisterSignalResponse register_response;
 
-    register_request.set_ecu_name(ecu_name);
-    register_request.set_signal_name(sig_name);
-    register_request.set_signal_direction(
-        signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
-    register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
+    // register_request.set_ecu_name(ecu_name);
+    // register_request.set_signal_name(sig_name);
+    // register_request.set_signal_direction(
+    //     signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
+    // register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
 
-    status =
-        stub_->RegisterSignal(&context, register_request, &register_response);
-    if (!status.ok()) {
-        std::cout << status.error_code() << ": " << status.error_message()
-                  << std::endl;
-    }
+    // status =
+    //     stub_->RegisterSignal(&context, register_request, &register_response);
+    // if (!status.ok()) {
+    //     std::cout << status.error_code() << ": " << status.error_message()
+    //               << std::endl;
+    // }
 
-    if (!register_response.status()) {
-        std::cout << "register signal error: " << register_response.error()
-                  << std::endl;
-    }
+    // if (!register_response.status()) {
+    //     std::cout << "register signal error: " << register_response.error()
+    //               << std::endl;
+    // }
+
+    RegisterIO(ecu_name, sig_name, 
+        signals::SignalDirection::SIGNAL_DIRECTION_INPUT, signals::SignalType::SIGNAL_TYPE_DIGITAL);
 }
 
 void SilClient::RegisterDigitalOutput(std::string ecu_name,
                                       std::string sig_name) {
-    grpc::Status status;
-    grpc::ClientContext context;
-    signals::RegisterSignalRequest register_request;
-    signals::RegisterSignalResponse register_response;
+    // grpc::Status status;
+    // grpc::ClientContext context;
+    // signals::RegisterSignalRequest register_request;
+    // signals::RegisterSignalResponse register_response;
 
-    register_request.set_ecu_name(ecu_name);
-    register_request.set_signal_name(sig_name);
-    register_request.set_signal_direction(
-        signals::SignalDirection::SIGNAL_DIRECTION_OUTPUT);
-    register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
+    // register_request.set_ecu_name(ecu_name);
+    // register_request.set_signal_name(sig_name);
+    // register_request.set_signal_direction(
+    //     signals::SignalDirection::SIGNAL_DIRECTION_OUTPUT);
+    // register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
 
-    status =
-        stub_->RegisterSignal(&context, register_request, &register_response);
-    if (!status.ok()) {
-        std::cout << status.error_code() << ": " << status.error_message()
-                  << std::endl;
-    }
+    // status =
+    //     stub_->RegisterSignal(&context, register_request, &register_response);
+    // if (!status.ok()) {
+    //     std::cout << status.error_code() << ": " << status.error_message()
+    //               << std::endl;
+    // }
 
-    if (!register_response.status()) {
-        std::cout << "register signal error: " << register_response.error()
-                  << std::endl;
-    }
+    // if (!register_response.status()) {
+    //     std::cout << "register signal error: " << register_response.error()
+    //               << std::endl;
+    // }
+
+    RegisterIO(ecu_name, sig_name, 
+        signals::SignalDirection::SIGNAL_DIRECTION_OUTPUT, signals::SignalType::SIGNAL_TYPE_DIGITAL);
 }
 
 void SilClient::RegisterAnalogInput(std::string ecu_name,
                                     std::string sig_name) {
+    // grpc::Status status;
+    // grpc::ClientContext context;
+    // signals::RegisterSignalRequest register_request;
+    // signals::RegisterSignalResponse register_response;
+
+    // register_request.set_ecu_name(ecu_name);
+    // register_request.set_signal_name(sig_name);
+    // register_request.set_signal_direction(
+    //     signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
+    // register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_ANALOG);
+
+    // status =
+    //     stub_->RegisterSignal(&context, register_request, &register_response);
+    // if (!status.ok()) {
+    //     std::cout << status.error_code() << ": " << status.error_message()
+    //               << std::endl;
+    // }
+
+    // if (!register_response.status()) {
+    //     std::cout << "register signal error: " << register_response.error()
+    //               << std::endl;
+    // }
+
+    RegisterIO(ecu_name, sig_name, 
+        signals::SignalDirection::SIGNAL_DIRECTION_INPUT, signals::SignalType::SIGNAL_TYPE_ANALOG)
+
+}
+
+void SilClient::SetDigitalLevel(std::string ecu_name, std::string sig_name,
+                                bool level) {
+//     grpc::Status status;
+//     grpc::ClientContext context;
+//     signals::WriteSignalRequest write_request;
+//     signals::WriteSignalResponse write_response;
+
+//     write_request.set_ecu_name(ecu_name);
+//     write_request.set_signal_name(sig_name);
+//     write_request.mutable_value_digital()->set_level(level);
+
+//     status = stub_->WriteSignal(&context, write_request, &write_response);
+//     if (!status.ok()) {
+//         std::cout << status.error_code() << ": " << status.error_message()
+//                   << std::endl;
+//         return;
+//     }
+
+//     if (!write_response.status()) {
+//         std::cout << "write response error: " << write_response.error()
+//                   << std::endl;
+//         return;
+//     }
+
+    SetRegister(ecu_name, sig_name, level);
+}
+
+bool SilClient::ReadDigitalLevel(std::string ecu_name, std::string sig_name) {
+    // grpc::Status status;
+    // grpc::ClientContext context;
+    // signals::ReadSignalRequest read_request;
+    // signals::ReadSignalResponse read_response;
+
+    // read_request.set_ecu_name(ecu_name);
+    // read_request.set_signal_name(sig_name);
+    // read_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
+    // read_request.set_signal_direction(
+    //     signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
+
+    // status = stub_->ReadSignal(&context, read_request, &read_response);
+    // if (!status.ok()) {
+    //     std::cout << status.error_code() << ": " << status.error_message()
+    //               << std::endl;
+    //     return false;
+    // }
+
+    // if (!read_response.status()) {
+    //     std::cout << "write response error: " << read_response.error()
+    //               << std::endl;
+    //     return false;
+    // }
+
+    // return read_response.value_digital().level();
+
+    signals::ReadSignalResponse read_response;
+
+    ReadRegister(ecu_name, sig_name, 
+        signals::SignalDirection::SIGNAL_DIRECTION_INPUT, 
+        signals::SignalType::SIGNAL_TYPE_ANALOG, &read_response);
+
+    return read_response.value_digital().level();
+
+}
+
+double SilClient::ReadAdcVoltage(std::string ecu_name, std::string sig_name) {
+    // grpc::Status status;
+    // grpc::ClientContext context;
+    // signals::ReadSignalRequest read_request;
+    // signals::ReadSignalResponse read_response;
+
+    // read_request.set_ecu_name(ecu_name);
+    // read_request.set_signal_name(sig_name);
+    // read_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_ANALOG);
+    // read_request.set_signal_direction(
+    //     signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
+
+    // status = stub_->ReadSignal(&context, read_request, &read_response);
+    // if (!status.ok()) {
+    //     std::cout << status.error_code() << ": " << status.error_message()
+    //               << std::endl;
+    //     return 0.0;
+    // }
+
+    // if (!read_response.status()) {
+    //     std::cout << "write response error: " << read_response.error()
+    //               << std::endl;
+    //     return 0.0;
+    // }
+
+    signals::ReadSignalResponse read_response;
+
+    ReadRegister(ecu_name, sig_name, 
+        signals::SignalDirection::SIGNAL_DIRECTION_INPUT, 
+        signals::SignalType::SIGNAL_TYPE_ANALOG, &read_response);
+
+    if (!read_response.has_value_analog()) {
+        std::cout << "expected adc value got: " << read_response.value_case()
+                  << std::endl;
+    }
+
+    return read_response.value_analog().voltage();
+}
+
+void RegisterIO(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, signals::SignalType sig_type) {
     grpc::Status status;
     grpc::ClientContext context;
     signals::RegisterSignalRequest register_request;
@@ -82,9 +220,8 @@ void SilClient::RegisterAnalogInput(std::string ecu_name,
 
     register_request.set_ecu_name(ecu_name);
     register_request.set_signal_name(sig_name);
-    register_request.set_signal_direction(
-        signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
-    register_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_ANALOG);
+    register_request.set_signal_direction(sig_dir);
+    register_request.set_signal_type(sig_type);
 
     status =
         stub_->RegisterSignal(&context, register_request, &register_response);
@@ -99,8 +236,7 @@ void SilClient::RegisterAnalogInput(std::string ecu_name,
     }
 }
 
-void SilClient::SetDigitalLevel(std::string ecu_name, std::string sig_name,
-                                bool level) {
+void SetRegister(std::string ecu_name, std::string sig_name, bool level) {
     grpc::Status status;
     grpc::ClientContext context;
     signals::WriteSignalRequest write_request;
@@ -124,47 +260,19 @@ void SilClient::SetDigitalLevel(std::string ecu_name, std::string sig_name,
     }
 }
 
-bool SilClient::ReadDigitalLevel(std::string ecu_name, std::string sig_name) {
+void ReadRegister(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, 
+    signals::SignalType sig_type, signals::ReadSignalResponse &read_response) {
+
     grpc::Status status;
     grpc::ClientContext context;
     signals::ReadSignalRequest read_request;
-    signals::ReadSignalResponse read_response;
 
     read_request.set_ecu_name(ecu_name);
     read_request.set_signal_name(sig_name);
-    read_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_DIGITAL);
-    read_request.set_signal_direction(
-        signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
+    read_request.set_signal_type(sig_type);
+    read_request.set_signal_direction(sig_dir);
 
-    status = stub_->ReadSignal(&context, read_request, &read_response);
-    if (!status.ok()) {
-        std::cout << status.error_code() << ": " << status.error_message()
-                  << std::endl;
-        return false;
-    }
-
-    if (!read_response.status()) {
-        std::cout << "write response error: " << read_response.error()
-                  << std::endl;
-        return false;
-    }
-
-    return read_response.value_digital().level();
-}
-
-double SilClient::ReadAdcVoltage(std::string ecu_name, std::string sig_name) {
-    grpc::Status status;
-    grpc::ClientContext context;
-    signals::ReadSignalRequest read_request;
-    signals::ReadSignalResponse read_response;
-
-    read_request.set_ecu_name(ecu_name);
-    read_request.set_signal_name(sig_name);
-    read_request.set_signal_type(signals::SignalType::SIGNAL_TYPE_ANALOG);
-    read_request.set_signal_direction(
-        signals::SignalDirection::SIGNAL_DIRECTION_INPUT);
-
-    status = stub_->ReadSignal(&context, read_request, &read_response);
+    status = stub_->ReadSignal(&context, read_request, read_response);
     if (!status.ok()) {
         std::cout << status.error_code() << ": " << status.error_message()
                   << std::endl;
@@ -172,17 +280,11 @@ double SilClient::ReadAdcVoltage(std::string ecu_name, std::string sig_name) {
     }
 
     if (!read_response.status()) {
-        std::cout << "write response error: " << read_response.error()
+        std::cout << "write response error: " << read_response->error()
                   << std::endl;
         return 0.0;
     }
 
-    if (!read_response.has_value_analog()) {
-        std::cout << "expected adc value got: " << read_response.value_case()
-                  << std::endl;
-    }
-
-    return read_response.value_analog().voltage();
 }
 
 }  // namespace mcal::raspi::sil

--- a/firmware/validation/sil/sil_client.h
+++ b/firmware/validation/sil/sil_client.h
@@ -38,7 +38,7 @@ private:
         signals::SignalType sig_type);
     void SetRegister(std::string ecu_name, std::string sig_name, bool level);
     void ReadRegister(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, 
-        signals::SignalType sig_type, signals::ReadSignalResponse read_response);
+        signals::SignalType sig_type, signals::ReadSignalResponse &read_response);
 
 };
 

--- a/firmware/validation/sil/sil_client.h
+++ b/firmware/validation/sil/sil_client.h
@@ -33,6 +33,13 @@ public:
 private:
     std::string addr_;
     std::unique_ptr<signals::Signals::Stub> stub_;
+
+    void RegisterIO(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, 
+        signals::SignalType sig_type);
+    void SetRegister(std::string ecu_name, std::string sig_name, bool level);
+    void ReadRegister(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, 
+        signals::SignalType sig_type, signals::ReadSignalResponse read_response);
+
 };
 
 }  // namespace val::sil


### PR DESCRIPTION
Created the private functions in sil_client.cc and sil_client.h:

## RegisterIO (std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, signals::SignalType sig_type)
Handles common logic between the RegisterDigitalInput, RegisterDigitalOutput, and RegisterAnalogInput functions. 
There are differences in how each Register function uses Signal Direction and Signal Type, therefore pass it in as an argument. 

## ReadRegister(std::string ecu_name, std::string sig_name, signals::SignalDirection sig_dir, signals::SignalType sig_type, signals::ReadSignalResponse read_response);

Handles common logic between ReadDigitalLevel and ReadAdcVoltage
There are multiple differences between these two functions, so I decided to leave some code unabstracted. 
The initialization of read_response is left unabstracted, therefore needing a pass by reference. 

## SetRegister(std::string ecu_name, std::string sig_name, bool level);
Only one function requires the SetRegister function, but still implemented an abstracted version for future use. 

---

Update 01-08:
I am figuring out how to compile with gRPC and protobuf


