### PR TITLE
CAN database structure draft

### DIFF
--- a/scripts/cangen/cangen/database.py
+++ b/scripts/cangen/cangen/database.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Dict, List, Set, Optional, Type, Union
+
+class SignalType(Enum):
+    INTEGRAL = auto()
+    FLOATING = auto()
+
+class Endian(Enum):
+    BIG = auto()
+    LITTLE = auto()
+
+@dataclass
+class Signal:
+    name: str # 1-32 chars, only [A-z], digits, and underscores
+    start_bit: int # bit 0-63
+    length: int # 1-64 bits
+    endianness: Endian
+    is_signed: bool
+    minimum: Union[int, float]
+    maximum: Union[int, float]
+    unit: Optional[str] = None
+    signal_type: SignalType
+    receivers: Set[Node]
+    description: Optional[str] = None
+
+    # Not needed for INTEGRAL signals
+    scale: Optional[float] = None
+    offset: Optional[float] = None
+
+@dataclass
+class Message:
+    name: str # 1-32 chars, only [A-z], digits, and underscores
+    id: int # 0-2047 (11-bits) or 0-536870911 (29-bits for extended IDs)
+    length: int # 0-8 bytes
+    sender: Node
+    signals: List[Signal]
+    frequency: int
+    description: Optional[str] = None
+
+@dataclass
+class Node:
+    name: str
+    description: Optional[str] = None
+
+@dataclass
+class Bus:
+    name: str
+    baud_rate: int
+    nodes: Set[Node]
+    messages: List[Message]
+    description: Optional[str] = None
+
+@dataclass
+class Database:
+    busses: Set[Bus]
+    enum_types: Dict[str, Type[Enum]] = field(default_factory=dict) 
+    description: Optional[str] = None

--- a/scripts/cangen/cangen/database.py
+++ b/scripts/cangen/cangen/database.py
@@ -4,15 +4,11 @@ from enum import Enum, auto
 from typing import Dict, List, Set, Optional, Type
 from abc import ABC
 
+
 class Endian(Enum):
     BIG = auto()
     LITTLE = auto()
 
-class IntegralType(Enum):
-    BOOLEAN = auto()
-    INTEGER = auto()
-    UNSIGNED_INTEGER = auto()
-    ENUM = auto()
 
 @dataclass
 class Bus:
@@ -20,39 +16,56 @@ class Bus:
     baud_rate: float
     nodes: Set[Node]
     messages: List[Message]
-    enum_types: Dict[str, Type[Enum]] = field(default_factory=dict) 
+    enum_types: Dict[str, Type[Enum]] = field(default_factory=dict)
     description: Optional[str] = None
+
 
 @dataclass
 class Node:
     name: str
     description: Optional[str] = None
 
+
 @dataclass
 class Message:
-    name: str # 1-32 chars, only [A-z], digits, and underscores
-    id: int # 0-2047 (11-bits) or 0-536870911 (29-bits for extended IDs)
+    name: str  # 1-32 chars, only [A-z], digits, and underscores
+    id: int  # 0-2047 (11-bits) or 0-536870911 (29-bits for extended IDs)
     is_extended_id: bool
-    length: int # 0-8 bytes
+    length: int  # 0-8 bytes
     sender: Node
     signals: List[Signal]
     receivers: Set[Node]
     frequency: float
     description: Optional[str] = None
 
+
 @dataclass
 class Signal(ABC):
-    name: str # 1-32 chars, only [A-z], digits, and underscores
-    start_bit: int # bit 0-63
-    length: int # 1-64 bits
+    name: str  # 1-32 chars, only [A-z], digits, and underscores
+    start_bit: int  # bit 0-63
+    length: int  # 1-64 bits
     endianness: Endian
-    additional_receivers: Optional[Set[Node]] = None # Currently all signals in a message are sent to the same receivers, but additional receivers can be specified for each signal if needed
+    additional_receivers: Optional[Set[Node]] = (
+        None  # Currently all signals in a message are sent to the same receivers, but additional receivers can be specified for each signal if needed
+    )
     description: Optional[str] = None
+
 
 @dataclass
 class IntegralSignal(Signal):
-    integral_type: IntegralType
+    is_signed: bool
     value_range: tuple[int, int]
+
+
+@dataclass
+class BooleanSignal(Signal):
+    pass
+
+
+@dataclass
+class EnumSignal(Signal):
+    enum_config: str
+
 
 @dataclass
 class FloatingSignal(Signal):

--- a/scripts/cangen/cangen/database.py
+++ b/scripts/cangen/cangen/database.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Dict, List, Set, Optional, Type
+from abc import ABC
 
 class Endian(Enum):
     BIG = auto()
@@ -40,7 +41,7 @@ class Message:
     description: Optional[str] = None
 
 @dataclass
-class Signal:
+class Signal(ABC):
     name: str # 1-32 chars, only [A-z], digits, and underscores
     start_bit: int # bit 0-63
     length: int # 1-64 bits


### PR DESCRIPTION
Here's some design decisions I took
- `scale` and `offset` are optional, as they are not used for `INTEGRAL` signals
    - Should we have a post-initialization hook to validate that these values are not defined for `INTEGRAL` signals?
- `unit` is optional, as many signals have empty strings for units (e.g. see `veh.dbc`)
- Enums are stored at the Database level via a dictionary