### PR TITLE
LV Bug Fixes

### DIFF
--- a/firmware/projects/LVController/main.cc
+++ b/firmware/projects/LVController/main.cc
@@ -161,23 +161,31 @@ public:
                 break;
 
             case MOTOR_CONTROLLER_SWITCH_SEQ: {
-                static uint8_t switch_step = 0;
-                if (on_enter_) switch_step = 0;
+                // static uint8_t switch_step = 0;
+                // if (on_enter_) switch_step = 0;
 
-                // verify this logic
-                switch (switch_step) {
-                    case 0:
-                        bindings::motor_ctrl_switch_en.SetHigh();
-                        break;
-                    case 1:
-                        bindings::motor_ctrl_switch_en.SetLow();
-                        break;
-                    case 2:
-                        bindings::motor_ctrl_switch_en.SetHigh();
-                        transition = DCDC_ON;
-                        break;
+                bindings::motor_ctrl_switch_en.SetLow();
+
+                if (elapsed > 5000) {
+                    auto m = veh_can.GetRxLvSwitch();
+                    if (m.has_value()) {
+                        bindings::motor_ctrl_switch_en.Set(m->SwitchClose());
+                    }
                 }
-                switch_step++;
+
+                // // verify this logic --> DEFINITELY INCORRECT
+                // switch (switch_step) {
+                //     case 0:
+                //         break;
+                //     case 1:
+                //         bindings::motor_ctrl_switch_en.SetLow();
+                //         break;
+                //     case 2:
+                //         bindings::motor_ctrl_switch_en.SetHigh();
+                //         transition = DCDC_ON;
+                //         break;
+                // }
+                // switch_step++;
             } break;
 
             case DCDC_ON:
@@ -261,7 +269,7 @@ public:
             state_ == POWERTRAIN_FAN_ON || state_ == POWERTRAIN_FAN_SWEEP ||
             state_ == READY_TO_DRIVE;
 
-        if (check_shutdown) {
+        if (false && check_shutdown) {  // temporary -> not on EV5
             const float kNoCurrentThresholdAmp = 0.5;  // what should this be?
             bool lost_lv_comms =
                 false;  // this should come from a SPI heartbeat
@@ -321,6 +329,8 @@ int main(void) {
         //     bindings::imd_fault.Read(),
         //                 time_ms);
         // }
+
+        bindings::tssi_en.Set(time_ms & (1 << 11));
 
         UpdateBrakeLight();
 

--- a/firmware/projects/LVController/platforms/stm32-ev6/bindings.cc
+++ b/firmware/projects/LVController/platforms/stm32-ev6/bindings.cc
@@ -138,7 +138,8 @@ void DelayMS(uint32_t milliseconds) {
 }
 
 int GetTick() {
-    return HAL_GetTick();
+    static uint32_t first_tick = HAL_GetTick();
+    return HAL_GetTick() - first_tick;
 }
 
 }  // namespace bindings

--- a/firmware/projects/LVController/platforms/stm32-ev6/bindings.cc
+++ b/firmware/projects/LVController/platforms/stm32-ev6/bindings.cc
@@ -111,7 +111,7 @@ DigitalOutput& imu_gps_en = mcal::imu_gps_en;
 DigitalOutput& raspberry_pi_en = mcal::raspberry_pi_en;
 DigitalOutput& shutdown_circuit_en = mcal::shutdown_circuit_en;
 
-// DCDC System & Measurement = mcal::Measurement
+// DCDC System & Measurement
 DigitalOutput& dcdc_en = mcal::dcdc_en;
 DigitalOutput& dcdc_sense_select = mcal::dcdc_sense_select;
 AnalogInput& dcdc_sense = mcal::dcdc_sense;

--- a/firmware/projects/LVController/platforms/stm32f767/bindings.cc
+++ b/firmware/projects/LVController/platforms/stm32f767/bindings.cc
@@ -151,8 +151,6 @@ AnalogInput& suspension_travel3 = mcal::suspension_travel3;
 AnalogInput& suspension_travel4 = mcal::suspension_travel4;
 CanBase& veh_can_base = mcal::veh_can_base;
 
-static uint32_t first_tick;
-
 void Initialize() {
     SystemClock_Config();
     HAL_Init();
@@ -162,8 +160,6 @@ void Initialize() {
     MX_TIM2_Init();
 
     mcal::veh_can_base.Setup();
-
-    first_tick = HAL_GetTick();
 }
 
 void DelayMS(uint32_t milliseconds) {
@@ -171,6 +167,7 @@ void DelayMS(uint32_t milliseconds) {
 }
 
 int GetTick() {
+    static uint32_t first_tick = HAL_GetTick();
     return HAL_GetTick() - first_tick;
 }
 

--- a/firmware/projects/LVController/platforms/stm32f767/bindings.cc
+++ b/firmware/projects/LVController/platforms/stm32f767/bindings.cc
@@ -151,6 +151,8 @@ AnalogInput& suspension_travel3 = mcal::suspension_travel3;
 AnalogInput& suspension_travel4 = mcal::suspension_travel4;
 CanBase& veh_can_base = mcal::veh_can_base;
 
+static uint32_t first_tick;
+
 void Initialize() {
     SystemClock_Config();
     HAL_Init();
@@ -160,6 +162,8 @@ void Initialize() {
     MX_TIM2_Init();
 
     mcal::veh_can_base.Setup();
+
+    first_tick = HAL_GetTick();
 }
 
 void DelayMS(uint32_t milliseconds) {
@@ -167,7 +171,7 @@ void DelayMS(uint32_t milliseconds) {
 }
 
 int GetTick() {
-    return HAL_GetTick();
+    return HAL_GetTick() - first_tick;
 }
 
 }  // namespace bindings

--- a/firmware/projects/LVController/platforms/stm32f767/cubemx/board_config.ioc
+++ b/firmware/projects/LVController/platforms/stm32f767/cubemx/board_config.ioc
@@ -72,6 +72,7 @@ Mcu.UserName=STM32F767ZITx
 MxCube.Version=6.12.0
 MxDb.Version=DB.6.0.120
 NVIC.BusFault_IRQn=true\:0\:0\:false\:false\:true\:false\:false\:false
+NVIC.CAN3_RX0_IRQn=true\:0\:0\:false\:false\:true\:true\:true\:true
 NVIC.DebugMonitor_IRQn=true\:0\:0\:false\:false\:true\:false\:false\:false
 NVIC.ForceEnableDMAVector=true
 NVIC.HardFault_IRQn=true\:0\:0\:false\:false\:true\:false\:false\:false

--- a/firmware/projects/veh.dbc
+++ b/firmware/projects/veh.dbc
@@ -35,6 +35,8 @@ BS_:
 
 BU_: PC_SG BMS FC TMS CANmod LVC RPI
 
+BO_ 110 LvSwitch: 6 PC_SG
+ SG_ SwitchClose : 0|8@1+ (1,0) [0|1] ""  LVC
 
 BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
  SG_ FC_userBtnL : 0|1@1+ (1,0) [0|1] "" Vector__XXX

--- a/firmware/projects/veh.dbc
+++ b/firmware/projects/veh.dbc
@@ -42,11 +42,8 @@ BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
 
 BO_ 111 LvControllerStatus: 6 LVC
  SG_ LvState : 0|8@1+ (1,0) [0|1] ""  RPI
- SG_ Elapsed : 8|32@1+ (1,0) [0|1] ""  RPI
+ SG_ Elapsed : 8|32@1- (1,0) [0|1] ""  RPI
  SG_ Flag : 40|1@1+ (1,0) [0|1] ""  RPI
-
-BO_ 112 FcControllerStatus: 1 FC
- SG_ FcState : 0|8@1+ (1,0) [0|1] "" LVC 
 
 BO_ 114 BrakeLight: 1 FC
  SG_ Enable : 0|1@1+ (1,0) [0|1] "" LVC 


### PR DESCRIPTION
Problem: LV wasn't receiving CAN messages.
Fix: Enabled CAN RX0 interrupt (required by the stm32 mcal CAN driver)

Problem: State machine wasn't transitioning.
Source: HAL_GetTick was returning a `uint32_t` above the `int` range, messing with the elapsed time calculation.
Fix: Record the first timestamp and subtract off all subsequent GetTick calls