### PR TITLE
Fix pre-commit "File Exists" error.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
         name: Run git-clang-format
         entry: git clang-format --style=file --staged
         language: python
+        require_serial: true
         stages: [commit]
         additional_dependencies:
           - clang-format~=19.0


### PR DESCRIPTION
`pre-commit` was attempting to optimize the action by running several instances of `git clang-format` in parallel, but these actions must be executed serially since they each create an `index.lock` file.

Discovered this fix from https://github.com/skupperproject/skupper-router/pull/802/files