### PR TITLE
Add docs link to Kvaser driver

### DIFF
--- a/docs/docs/tutorials/busmaster/index.md
+++ b/docs/docs/tutorials/busmaster/index.md
@@ -2,9 +2,11 @@
 
 ## You will need
 
-- Busmaster software v3.2.2.
+- Busmaster software v3.2.2 <https://rbei-etas.github.io/busmaster/>
 
-    > Install from <https://rbei-etas.github.io/busmaster/>
+- Kvaser Drivers <https://kvaser.com/download/>
+
+    > Kvaser drivers are only available for Windows and Linux, so you cannot follow this tutorial on MacOS.
 
 - The Kvaser USB CAN adapter (which should be kept in the bay).
 


### PR DESCRIPTION
I forgot to give instructions to install the Kvaser drivers on https://macformula.github.io/racecar/tutorials/busmaster/

# Before
![image](https://github.com/user-attachments/assets/13dd2335-bd01-4482-b769-5eae77416bbd)

# After
![image](https://github.com/user-attachments/assets/35235453-8421-41d8-9dfe-549be66fd144)
