### PR TITLE
Add Hash version for DBC files to sync for avoiding CAN bus inconsistencies

### DIFF
--- a/firmware/mcal/linux/periph/CMakeLists.txt
+++ b/firmware/mcal/linux/periph/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(mcal-linux
     can.cc
     digital_input.cc
     digital_output.cc
+    pwm_output.cc
 )
 
 add_subdirectory(vcan)

--- a/firmware/mcal/linux/periph/can.cc
+++ b/firmware/mcal/linux/periph/can.cc
@@ -21,7 +21,8 @@ static can_frame to_can_frame(const shared::can::RawMessage& msg) {
 
 namespace mcal::lnx::periph {
 
-CanBase::CanBase(std::string iface) : socket_(iface) {}
+CanBase::CanBase(std::string iface, bool log_rx)
+    : socket_(iface), log_rx_(log_rx) {}
 
 void CanBase::Setup() {
     socket_.Open();
@@ -52,9 +53,13 @@ void CanBase::StartReading() {
 
         shared::can::RawMessage raw_msg(frame.can_id, true, frame.can_dlc,
                                         frame.data);
-        std::cout << std::format("CanBase {}: Received\n| {}",
-                                 socket_.GetIface(), raw_msg)
-                  << std::endl;
+
+        if (log_rx_) {
+            // this can get noisy, so set `log_rx=false` to disable it
+            std::cout << std::format("CanBase {}: Received\n| {}",
+                                     socket_.GetIface(), raw_msg)
+                      << std::endl;
+        }
 
         AddToBus(raw_msg);
     }

--- a/firmware/mcal/linux/periph/can.hpp
+++ b/firmware/mcal/linux/periph/can.hpp
@@ -10,7 +10,7 @@ namespace mcal::lnx::periph {
 
 class CanBase : public shared::periph::CanBase {
 public:
-    CanBase(std::string can_iface);
+    CanBase(std::string can_iface, bool log_rx = true);
 
     void Setup();
     void Send(const shared::can::RawMessage&) override;
@@ -19,6 +19,7 @@ private:
     uint32_t GetTimestamp() const override;
 
     struct vcan::VcanSocket socket_;
+    bool log_rx_;
 
     std::thread reader_thread_;
     void StartReading();

--- a/firmware/mcal/linux/periph/pwm_output.cc
+++ b/firmware/mcal/linux/periph/pwm_output.cc
@@ -1,0 +1,49 @@
+#include "pwm_output.hpp"
+
+#include <format>
+#include <iostream>
+#include <string>
+
+#include "shared/util/mappers/clamper.hpp"
+
+namespace mcal::lnx::periph {
+
+PWMOutput::PWMOutput(std::string name) {}
+
+void PWMOutput::Start() {
+    std::cout << std::format("Starting PWM {}", name_) << std::endl;
+}
+
+void PWMOutput::Stop() {
+    std::cout << std::format("Stopping PWM {}", name_) << std::endl;
+}
+
+void PWMOutput::SetDutyCycle(float duty_cycle) {
+    duty_cycle = shared::util::Clamper<float>::Evaluate(duty_cycle, 0, 100);
+
+    std::cout << std::format("Setting PWM {} duty cycle to {:.3g}%", name_,
+                             duty_cycle)
+              << std::endl;
+}
+
+float PWMOutput::GetDutyCycle() {
+    std::cout << std::format("PWM {} has duty cycle {:.3g}%", name_, duty_)
+              << std::endl;
+    return duty_;
+}
+
+void PWMOutput::SetFrequency(float frequency) {
+    frequency_ = std::max((float)0, frequency);
+
+    std::cout << std::format("Setting PWM {} frequency to {:.3f} Hz", name_,
+                             frequency_)
+              << std::endl;
+}
+
+float PWMOutput::GetFrequency() {
+    std::cout << std::format("PWM {} has frequency {:.3f} Hz", name_,
+                             frequency_)
+              << std::endl;
+    return frequency_;
+}
+}  // namespace mcal::lnx::periph

--- a/firmware/mcal/linux/periph/pwm_output.hpp
+++ b/firmware/mcal/linux/periph/pwm_output.hpp
@@ -1,0 +1,24 @@
+#include <string>
+
+#include "shared/periph/pwm.hpp"
+
+namespace mcal::lnx::periph {
+
+class PWMOutput : public shared::periph::PWMOutput {
+public:
+    PWMOutput(std::string name);
+
+    void Start() override;
+    void Stop() override;
+    void SetDutyCycle(float duty_cycle) override;
+    float GetDutyCycle() override;
+    void SetFrequency(float frequency) override;
+    float GetFrequency() override;
+
+private:
+    float duty_;
+    float frequency_;
+    std::string name_;
+};
+
+}  // namespace mcal::lnx::periph

--- a/firmware/projects/FrontController/main.cc
+++ b/firmware/projects/FrontController/main.cc
@@ -63,7 +63,8 @@ VehicleDynamics vd{pedal_to_torque};
 // Global Governer input defined
 Governor::Input gov_in{};
 
-TxFC_Status fc_status{0, 0, 0, 0, 0, static_cast<uint8_t>(HashStatus::WAITING)};
+using HashStatus = TxFC_Status::HashStatus_t;
+TxFC_Status fc_status{0, 0, 0, 0, HashStatus::WAITING};
 
 void UpdateControls() {
     // NOTE #1: For defining inputs, I commented out inputs where I didn't know
@@ -87,7 +88,6 @@ void UpdateControls() {
     fc_status.di_status = static_cast<uint8_t>(gov_in.di_sts);
     fc_status.mi_status = static_cast<uint8_t>(gov_in.mi_sts);
     fc_status.bm_status = static_cast<uint8_t>(gov_in.bm_sts);
-    fc_status.user_flag = false;  // bindings::start_button.Read(),
 
     // Driver Interface update
     DriverInterface::Input di_in = {
@@ -184,7 +184,7 @@ int main(void) {
 
     auto hash_version = veh_can_bus.GetRxSyncHashVersion();
     while (!hash_version.has_value()) {
-        fc_status.hash_status = static_cast<uint8_t>(HashStatus::WAITING);
+        fc_status.hash_status = HashStatus::WAITING;
         veh_can_bus.Send(fc_status);
 
         bindings::DelayMs(100);
@@ -193,13 +193,13 @@ int main(void) {
     }
     if (hash_version->HashVersion() != generated::can::kVehDbcHashVersion) {
         while (true) {
-            fc_status.hash_status = static_cast<uint8_t>(HashStatus::INVALID);
+            fc_status.hash_status = HashStatus::INVALID;
             veh_can_bus.Send(fc_status);
 
             bindings::DelayMs(100);
         }
     }
-    fc_status.hash_status = static_cast<uint8_t>(HashStatus::VALID);
+    fc_status.hash_status = HashStatus::VALID;
 
     bindings::dashboard_power_en.SetHigh();
 

--- a/firmware/projects/FrontController/main.cc
+++ b/firmware/projects/FrontController/main.cc
@@ -180,14 +180,16 @@ void UpdateControls() {
 }
 
 int main(void) {
+    bindings::Initialize();
+
     auto hash_version = veh_can_bus.GetRxSyncHashVersion();
-    if (hash_version.has_value() &&
-        hash_version->HashVersion() != generated::can::VEH_DBC_HASH_VERSION) {
-        // Add error throwing here
+    while (!hash_version.has_value()) {
+        hash_version = veh_can_bus.GetRxSyncHashVersion();
+    }
+    if (hash_version->HashVersion() != generated::can::VEH_DBC_HASH_VERSION) {
+        // Handle error
         return -1;
     }
-
-    bindings::Initialize();
 
     bindings::dashboard_power_en.SetHigh();
 

--- a/firmware/projects/FrontController/main.cc
+++ b/firmware/projects/FrontController/main.cc
@@ -186,7 +186,7 @@ int main(void) {
     while (!hash_version.has_value()) {
         hash_version = veh_can_bus.GetRxSyncHashVersion();
     }
-    if (hash_version->HashVersion() != generated::can::VEH_DBC_HASH_VERSION) {
+    if (hash_version->HashVersion() != generated::can::kVehDbcHashVersion) {
         // Handle error
         return -1;
     }

--- a/firmware/projects/FrontController/main.cc
+++ b/firmware/projects/FrontController/main.cc
@@ -63,7 +63,7 @@ VehicleDynamics vd{pedal_to_torque};
 // Global Governer input defined
 Governor::Input gov_in{};
 
-TxFC_Status fc_status{0,0,0,0,0,static_cast<uint8_t>(HashStatus::WAITING)};
+TxFC_Status fc_status{0, 0, 0, 0, 0, static_cast<uint8_t>(HashStatus::WAITING)};
 
 void UpdateControls() {
     // NOTE #1: For defining inputs, I commented out inputs where I didn't know

--- a/firmware/projects/FrontController/main.cc
+++ b/firmware/projects/FrontController/main.cc
@@ -180,6 +180,13 @@ void UpdateControls() {
 }
 
 int main(void) {
+    auto hash_version = veh_can_bus.GetRxSyncHashVersion();
+    if (hash_version.has_value() &&
+        hash_version->HashVersion() != generated::can::VEH_DBC_HASH_VERSION) {
+        // Add error throwing here
+        return -1;
+    }
+
     bindings::Initialize();
 
     bindings::dashboard_power_en.SetHigh();

--- a/firmware/projects/FrontController/platforms/linux/CMakeLists.txt
+++ b/firmware/projects/FrontController/platforms/linux/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_sources(main PRIVATE bindings.cc)
+target_link_libraries(main PRIVATE mcal-linux)

--- a/firmware/projects/FrontController/platforms/linux/bindings.cc
+++ b/firmware/projects/FrontController/platforms/linux/bindings.cc
@@ -1,0 +1,108 @@
+#include "../../bindings.hpp"
+
+#include <unistd.h>
+
+#include <chrono>
+#include <iostream>
+
+#include "mcal/linux/periph/analog_input.hpp"
+#include "mcal/linux/periph/can.hpp"
+#include "mcal/linux/periph/digital_input.hpp"
+#include "mcal/linux/periph/digital_output.hpp"
+
+namespace mcal {
+using namespace lnx::periph;
+
+// =========== CAN =========================================
+CanBase veh_can_base{"vcan0", false};
+CanBase pt_can_base{"vcan1", false};
+
+// =========== Vehicle Dynamics Sensors ====================
+AnalogInput suspension_travel1{"STP1"};
+AnalogInput suspension_travel2{"STP2"};
+AnalogInput wheel_speed_front_left{"WHEEL_SPEED_FRONT_LEFT"};    // A
+AnalogInput wheel_speed_front_right{"WHEEL_SPEED_FRONT_RIGHT"};  // A
+AnalogInput wheel_speed_rear_left{"WHEEL_SPEED_REAR_LEFT"};      // B
+AnalogInput wheel_speed_rear_right{"WHEEL_SPEED_REAR_RIGHT"};    // B
+
+// =========== Driver Control ==============================
+AnalogInput steering_angle_sensor{"STEERING_ANGLE_SENSOR"};
+AnalogInput accel_pedal_sensor1{"ACCEL_PEDAL_SENSOR1"};
+AnalogInput accel_pedal_sensor2{"ACCEL_PEDAL_SENSOR2"};
+AnalogInput brake_pressure_sensor{"BRAKE_PRESSURE_SENSOR"};
+
+// =========== Status Monitors =============================
+AnalogInput precharge_monitor{"PRECHARGE_MONITOR"};
+DigitalInput bspd_fault{"BSPD_FAULT"};
+
+// =========== Outputs =====================================
+DigitalOutput dashboard_power_en{"DASHBOARD_POWER_EN"};
+DigitalOutput imd_fault_led_en{"IMD_FAULT_LED_EN"};
+DigitalOutput bms_fault_led_en{"BMS_FAULT_LED_EN"};
+DigitalOutput ready_to_drive_sig_en{"READY_TO_DRIVE_SIG_EN"};
+DigitalOutput debug_led{"DEBUG_LED"};
+
+};  // namespace mcal
+
+namespace bindings {
+shared::periph::CanBase& veh_can_base = mcal::veh_can_base;
+shared::periph::CanBase& pt_can_base = mcal::pt_can_base;
+
+// =========== Vehicle Dynamics Sensors ====================
+shared::periph::AnalogInput& suspension_travel1 = mcal::suspension_travel1;
+shared::periph::AnalogInput& suspension_travel2 = mcal::suspension_travel2;
+shared::periph::AnalogInput& wheel_speed_front_left =
+    mcal::wheel_speed_front_left;  // A
+shared::periph::AnalogInput& wheel_speed_front_right =
+    mcal::wheel_speed_front_right;  // A
+shared::periph::AnalogInput& wheel_speed_rear_left =
+    mcal::wheel_speed_rear_left;  // B
+shared::periph::AnalogInput& wheel_speed_rear_right =
+    mcal::wheel_speed_rear_right;  // B
+
+// =========== Driver Control ==============================
+shared::periph::AnalogInput& steering_angle_sensor =
+    mcal::steering_angle_sensor;
+shared::periph::AnalogInput& accel_pedal_sensor1 = mcal::accel_pedal_sensor1;
+shared::periph::AnalogInput& accel_pedal_sensor2 = mcal::accel_pedal_sensor2;
+shared::periph::AnalogInput& brake_pressure_sensor =
+    mcal::brake_pressure_sensor;
+
+// =========== Status Monitors =============================
+shared::periph::AnalogInput& precharge_monitor = mcal::precharge_monitor;
+shared::periph::DigitalInput& bspd_fault = mcal::bspd_fault;
+
+// =========== Outputs =====================================
+shared::periph::DigitalOutput& dashboard_power_en = mcal::dashboard_power_en;
+shared::periph::DigitalOutput& imd_fault_led_en = mcal::imd_fault_led_en;
+shared::periph::DigitalOutput& bms_fault_led_en = mcal::bms_fault_led_en;
+shared::periph::DigitalOutput& ready_to_drive_sig_en =
+    mcal::ready_to_drive_sig_en;
+shared::periph::DigitalOutput& debug_led = mcal::debug_led;
+
+void Initialize() {
+    std::cout << "Initializing Linux" << std::endl;
+    mcal::veh_can_base.Setup();
+    mcal::pt_can_base.Setup();
+}
+
+int GetTickMs() {
+    using namespace std::chrono;
+    long now =
+        duration_cast<milliseconds>(system_clock::now().time_since_epoch())
+            .count();
+    static long start = now;  // only set on first call
+
+    return now - start;
+}
+
+void DelayMs(int ms) {
+    usleep(ms * 1000);
+}
+
+void SoftwareReset() {
+    std::cout << "Performing software reset. Will not proceed." << std::endl;
+    while (true) continue;
+}
+
+}  // namespace bindings

--- a/firmware/projects/FrontController/platforms/linux/mcal_conf.cmake
+++ b/firmware/projects/FrontController/platforms/linux/mcal_conf.cmake
@@ -1,0 +1,1 @@
+set(MCAL linux)

--- a/firmware/projects/FrontController/platforms/linux/vcan_setup.sh
+++ b/firmware/projects/FrontController/platforms/linux/vcan_setup.sh
@@ -1,0 +1,8 @@
+sudo modprobe -a can can_raw vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+ip link show vcan0
+
+sudo ip link add dev vcan1 type vcan
+sudo ip link set up vcan1
+ip link show vcan1

--- a/firmware/projects/LVController/main.cc
+++ b/firmware/projects/LVController/main.cc
@@ -110,12 +110,15 @@ public:
                     }
                 }
                 break;
-            
+
             case PWRUP_CHECK_HASH_STATUS: {
-                veh_can.Send(TxSyncHashVersion(generated::can::kVehDbcHashVersion));
+                veh_can.Send(
+                    TxSyncHashVersion(generated::can::kVehDbcHashVersion));
                 auto msg = veh_can.GetRxFC_Status();
 
-                if (msg.has_value() && msg->HashStatus() == static_cast<uint8_t>(HashStatus::VALID)) {
+                if (msg.has_value() &&
+                    msg->HashStatus() ==
+                        static_cast<uint8_t>(HashStatus::VALID)) {
                     transition = PWRUP_ACCUMULATOR_ON;
                 }
             } break;

--- a/firmware/projects/LVController/main.cc
+++ b/firmware/projects/LVController/main.cc
@@ -57,6 +57,7 @@ class StateMachine {
 
 public:
     using LvState = TxLvControllerStatus::LvState_t;
+    using HashStatus = RxFC_Status::HashStatus_t;
 
     StateMachine(int start_time)
         : state_(LvState::PWRUP_START), state_enter_time_(start_time) {}
@@ -117,8 +118,7 @@ public:
                 auto msg = veh_can.GetRxFC_Status();
 
                 if (msg.has_value() &&
-                    msg->HashStatus() ==
-                        static_cast<uint8_t>(HashStatus::VALID)) {
+                    msg->HashStatus() == HashStatus::VALID) {
                     transition = PWRUP_ACCUMULATOR_ON;
                 }
             } break;

--- a/firmware/projects/LVController/main.cc
+++ b/firmware/projects/LVController/main.cc
@@ -313,9 +313,9 @@ void UpdateBrakeLight() {
 }
 
 int main(void) {
-    veh_can.Send(TxSyncHashVersion(generated::can::VEH_DBC_HASH_VERSION));
-
     bindings::Initialize();
+
+    veh_can.Send(TxSyncHashVersion(generated::can::kVehDbcHashVersion));
 
     StateMachine fsm(bindings::GetTick());
 

--- a/firmware/projects/LVController/main.cc
+++ b/firmware/projects/LVController/main.cc
@@ -57,7 +57,7 @@ class StateMachine {
 
 public:
     using LvState = TxLvControllerStatus::LvState_t;
-    using HashStatus = RxFC_Status::HashStatus_t;
+    using DbcHashStatus = RxFC_Status::DbcHashStatus_t;
 
     StateMachine(int start_time)
         : state_(LvState::PWRUP_START), state_enter_time_(start_time) {}
@@ -113,12 +113,11 @@ public:
                 break;
 
             case PWRUP_CHECK_HASH_STATUS: {
-                veh_can.Send(
-                    TxSyncHashVersion(generated::can::kVehDbcHashVersion));
+                veh_can.Send(TxSyncDbcHash(generated::can::kVehDbcHash));
                 auto msg = veh_can.GetRxFC_Status();
 
                 if (msg.has_value() &&
-                    msg->HashStatus() == HashStatus::VALID) {
+                    msg->DbcHashStatus() == DbcHashStatus::VALID) {
                     transition = PWRUP_ACCUMULATOR_ON;
                 }
             } break;

--- a/firmware/projects/LVController/main.cc
+++ b/firmware/projects/LVController/main.cc
@@ -313,6 +313,8 @@ void UpdateBrakeLight() {
 }
 
 int main(void) {
+    veh_can.Send(TxSyncHashVersion(generated::can::VEH_DBC_HASH_VERSION));
+
     bindings::Initialize();
 
     StateMachine fsm(bindings::GetTick());

--- a/firmware/projects/LVController/platforms/linux/CMakeLists.txt
+++ b/firmware/projects/LVController/platforms/linux/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_sources(main PRIVATE bindings.cc)
+target_link_libraries(main PRIVATE mcal-linux)

--- a/firmware/projects/LVController/platforms/linux/bindings.cc
+++ b/firmware/projects/LVController/platforms/linux/bindings.cc
@@ -1,0 +1,114 @@
+#include "../../bindings.hpp"
+
+#include "mcal/linux/periph/analog_input.hpp"
+#include "mcal/linux/periph/can.hpp"
+#include "mcal/linux/periph/digital_input.hpp"
+#include "mcal/linux/periph/digital_output.hpp"
+#include "mcal/linux/periph/pwm_output.hpp"
+
+namespace mcal {
+using namespace lnx::periph;
+// Tractive System Status Indicator (2025 Rule EV.5.11.5)
+DigitalOutput tssi_en{"TSSI_EN"};
+DigitalOutput tssi_red_signal{"TSSI_RED_SIGNAL"};
+DigitalOutput tssi_green_signal{"TSSI_GREEN_SIGNAL"};
+DigitalInput imd_fault{"IMD_FAULT"};
+DigitalInput bms_fault{"BMS_FAULT"};
+
+// Powertrain Cooling
+DigitalOutput powertrain_pump1_en{"POWERTRAIN_PUMP1_EN"};
+DigitalOutput powertrain_pump2_en{"POWERTRAIN_PUMP2_EN"};
+DigitalOutput powertrain_fan1_en{"POWERTRAIN_FAN1_EN"};
+DigitalOutput powertrain_fan2_en{"POWERTRAIN_FAN2_EN"};
+PWMOutput powertrain_fan_pwm{"POWERTRAIN_FAN_PWM"};  // shared by both fans
+
+// Motor Controller (i.e. Inverters)
+DigitalOutput motor_controller_en{"MOTOR_CONTROLLER_EN"};
+DigitalOutput motor_ctrl_precharge_en{"MOTOR_CTRL_PRECHARGE_EN"};
+DigitalOutput motor_ctrl_switch_en{"MOTOR_CTRL_SWITCH_EN"};
+
+// Subsystems
+DigitalOutput accumulator_en{"ACCUMULATOR_EN"};
+DigitalOutput front_controller_en{"FRONT_CONTROLLER_EN"};
+DigitalOutput imu_gps_en{"IMU_GPS_EN"};
+DigitalOutput shutdown_circuit_en{"SHUTDOWN_CIRCUIT_EN"};
+
+// DCDC System & Measurement
+DigitalOutput dcdc_en{"DCDC_EN"};
+DigitalOutput dcdc_sense_select{"DCDC_SENSE_SELECT"};
+AnalogInput dcdc_sense{"DCDC_SENSE"};
+
+// Other IO
+DigitalOutput brake_light_en{"BRAKE_LIGHT_EN"};
+AnalogInput suspension_travel3{"SUSPENSION_TRAVEL3"};
+AnalogInput suspension_travel4{"SUSPENSION_TRAVEL4"};
+CanBase veh_can_base{"vcan0", false};
+}  // namespace mcal
+
+namespace bindings {
+
+// Tractive System Status Indicator (2025 Rule EV.5.11.5)
+shared::periph::DigitalOutput& tssi_en = mcal::tssi_en;
+shared::periph::DigitalOutput& tssi_red_signal = mcal::tssi_red_signal;
+shared::periph::DigitalOutput& tssi_green_signal = mcal::tssi_green_signal;
+shared::periph::DigitalInput& imd_fault = mcal::imd_fault;
+shared::periph::DigitalInput& bms_fault = mcal::bms_fault;
+
+// Powertrain Cooling
+shared::periph::DigitalOutput& powertrain_pump1_en = mcal::powertrain_pump1_en;
+shared::periph::DigitalOutput& powertrain_pump2_en = mcal::powertrain_pump2_en;
+shared::periph::DigitalOutput& powertrain_fan1_en = mcal::powertrain_fan1_en;
+shared::periph::DigitalOutput& powertrain_fan2_en = mcal::powertrain_fan2_en;
+shared::periph::PWMOutput& powertrain_fan_pwm =
+    mcal::powertrain_fan_pwm;  // shared by both fans
+
+// Motor Controller (i.e. Inverters)
+shared::periph::DigitalOutput& motor_controller_en = mcal::motor_controller_en;
+shared::periph::DigitalOutput& motor_ctrl_precharge_en =
+    mcal::motor_ctrl_precharge_en;
+shared::periph::DigitalOutput& motor_ctrl_switch_en =
+    mcal::motor_ctrl_switch_en;
+
+// Subsystems
+shared::periph::DigitalOutput& accumulator_en = mcal::accumulator_en;
+shared::periph::DigitalOutput& front_controller_en = mcal::front_controller_en;
+shared::periph::DigitalOutput& imu_gps_en = mcal::imu_gps_en;
+shared::periph::DigitalOutput& shutdown_circuit_en = mcal::shutdown_circuit_en;
+
+// DCDC System & Measurement
+shared::periph::DigitalOutput& dcdc_en = mcal::dcdc_en;
+shared::periph::DigitalOutput& dcdc_sense_select = mcal::dcdc_sense_select;
+shared::periph::AnalogInput& dcdc_sense = mcal::dcdc_sense;
+
+// Other IO
+shared::periph::DigitalOutput& brake_light_en = mcal::brake_light_en;
+shared::periph::AnalogInput& suspension_travel3 = mcal::suspension_travel3;
+shared::periph::AnalogInput& suspension_travel4 = mcal::suspension_travel4;
+shared::periph::CanBase& veh_can_base = mcal::veh_can_base;
+
+void Initialize() {
+    std::cout << "Initializing Linux platform for LVController" << std::endl;
+
+    mcal::veh_can_base.Setup();
+}
+
+int GetTick() {
+    using namespace std::chrono;
+    long now =
+        duration_cast<milliseconds>(system_clock::now().time_since_epoch())
+            .count();
+    static long start = now;  // only set on first call
+
+    return now - start;
+}
+
+void DelayMS(uint32_t ms) {
+    usleep(ms * 1000);
+}
+
+void SoftwareReset() {
+    std::cout << "Performing software reset. Will not proceed." << std::endl;
+    while (true) continue;
+}
+
+}  // namespace bindings

--- a/firmware/projects/LVController/platforms/linux/mcal_conf.cmake
+++ b/firmware/projects/LVController/platforms/linux/mcal_conf.cmake
@@ -1,0 +1,1 @@
+set(MCAL linux)

--- a/firmware/projects/LVController/platforms/linux/vcan_setup.sh
+++ b/firmware/projects/LVController/platforms/linux/vcan_setup.sh
@@ -1,0 +1,8 @@
+sudo modprobe -a can can_raw vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+ip link show vcan0
+
+sudo ip link add dev vcan1 type vcan
+sudo ip link set up vcan1
+ip link show vcan1

--- a/firmware/projects/veh.dbc
+++ b/firmware/projects/veh.dbc
@@ -45,6 +45,9 @@ BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
  SG_ FC_userBtnL : 0|1@1+ (1,0) [0|1] "" Vector__XXX
  SG_ FC_userBtnR : 0|1@1+ (1,0) [0|1] "" Vector__XXX
 
+BO_ 123 SyncHashVersion: 8 LVC
+ SG_ HashVersion : 0|64@1+ (1,0) [0|1] "" FC
+
 BO_ 111 LvControllerStatus: 6 LVC
  SG_ LvState : 0|8@1+ (1,0) [0|1] ""  RPI
  SG_ Elapsed : 8|32@1- (1,0) [0|1] ""  RPI

--- a/firmware/projects/veh.dbc
+++ b/firmware/projects/veh.dbc
@@ -45,8 +45,8 @@ BO_ 3221225472 VECTOR__INDEPENDENT_SIG_MSG: 0 Vector__XXX
  SG_ FC_userBtnL : 0|1@1+ (1,0) [0|1] "" Vector__XXX
  SG_ FC_userBtnR : 0|1@1+ (1,0) [0|1] "" Vector__XXX
 
-BO_ 123 SyncHashVersion: 8 LVC
- SG_ HashVersion : 0|64@1+ (1,0) [0|1] "" FC
+BO_ 123 SyncDbcHash: 8 LVC
+ SG_ DbcHash : 0|64@1+ (1,0) [0|1] "" FC
 
 BO_ 111 LvControllerStatus: 6 LVC
  SG_ LvState : 0|8@1+ (1,0) [0|1] ""  RPI
@@ -65,7 +65,7 @@ BO_ 255 FC_Status: 6 FC
  SG_ DiStatus : 8|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ MiStatus : 16|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ BmStatus : 24|8@1+ (1,0) [0|255] "" LVC, PC_SG
- SG_ HashStatus : 40|8@1+ (1,0) [0|255] "" LVC, PC_SG
+ SG_ DbcHashStatus : 40|8@1+ (1,0) [0|255] "" LVC, PC_SG
 
 BO_ 511 FC_msg: 8 FC
  SG_ FC_hvilSts : 60|1@1+ (1,0) [0|1] ""  PC_SG
@@ -241,7 +241,7 @@ BA_DEF_DEF_  "MultiplexExtEnabled" "No";
 VAL_ 109 ECU 0 "FrontController" 1 "LvController" 2 "TMS";
 VAL_ 111 LvState 0 "PWRUP_START" 1 "PWRUP_TSSI_ON" 2 "PWRUP_PERIPHERALS_ON" 3 "PWRUP_ACCUMULATOR_ON" 4 "PWRUP_MOTOR_PRECHARGE_ON" 5 "PWRUP_MOTOR_LV" 6 "PWRUP_MOTOR_PRECHARGE_OFF" 7 "PWRUP_SHUTDOWN_ON" 8 "MOTOR_CONTROLLER_SWITCH_SEQ" 9 "DCDC_ON" 10 "POWERTRAIN_PUMP_ON" 11 "POWERTRAIN_FAN_ON" 12 "POWERTRAIN_FAN_SWEEP" 13 "READY_TO_DRIVE" 14 "SHUTDOWN_DRIVER_WARNING" 15 "SHUTDOWN_PUMP_OFF" 16 "SHUTDOWN_FAN_OFF" 17 "SHUTDOWN_COMPLETE" 18 "PWRUP_CHECK_HASH_STATUS";
 VAL_ 112 FcState 0 "PWRUP_START" 1 "HVIL_OPEN";
-VAL_ 255 HashStatus 0 "WAITING" 1 "VALID" 2 "INVALID";
+VAL_ 255 DbcHashStatus 0 "WAITING" 1 "VALID" 2 "INVALID";
 VAL_ 255 VC_bmStatus 9 "err_running" 8 "bm_low_soc" 7 "hvil_interrupt" 6 "bm_running" 5 "precharge" 4 "init_precharge" 3 "bm_startup" 2 "bm_idle" 1 "bm_init" 0 "bm_unknown" ;
 VAL_ 255 VC_diStatus 8 "di_error" 7 "di_running" 6 "hv_start_req" 5 "ready_to_drive_req" 4 "waiting_for_driver" 3 "di_startup" 2 "di_idle" 1 "di_sts_init" 0 "di_unknown" ;
 VAL_ 255 VC_miStatus 7 "off" 6 "mi_sts_error" 5 "shutdown" 4 "running" 3 "ready" 2 "startup" 1 "sts_init" 0 "unknown" ;

--- a/firmware/projects/veh.dbc
+++ b/firmware/projects/veh.dbc
@@ -60,12 +60,13 @@ BO_ 113 SuspensionTravel34: 2 LVC
  SG_ STP3 : 0|8@1+ (1,0) [0|255] "" FC,RPI
  SG_ STP4 : 8|8@1+ (1,0) [0|255] "" FC,RPI
 
-BO_ 255 FC_Status: 5 FC
+BO_ 255 FC_Status: 6 FC
  SG_ GovStatus : 0|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ DiStatus : 8|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ MiStatus : 16|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ BmStatus : 24|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ UserFlag : 32|8@1+ (1,0) [0|255] "" LVC, PC_SG
+ SG_ HashStatus : 40|8@1+ (1,0) [0|255] "" LVC, PC_SG
 
 BO_ 511 FC_msg: 8 FC
  SG_ FC_hvilSts : 60|1@1+ (1,0) [0|1] ""  PC_SG
@@ -239,8 +240,9 @@ BA_DEF_  "MultiplexExtEnabled" ENUM  "No","Yes";
 BA_DEF_DEF_  "BusType" "CAN";
 BA_DEF_DEF_  "MultiplexExtEnabled" "No";
 VAL_ 109 ECU 0 "FrontController" 1 "LvController" 2 "TMS";
-VAL_ 111 LvState 0 "PWRUP_START" 1 "PWRUP_TSSI_ON" 2 "PWRUP_PERIPHERALS_ON" 3 "PWRUP_ACCUMULATOR_ON" 4 "PWRUP_MOTOR_PRECHARGE_ON" 5 "PWRUP_MOTOR_LV" 6 "PWRUP_MOTOR_PRECHARGE_OFF" 7 "PWRUP_SHUTDOWN_ON" 8 "MOTOR_CONTROLLER_SWITCH_SEQ" 9 "DCDC_ON" 10 "POWERTRAIN_PUMP_ON" 11 "POWERTRAIN_FAN_ON" 12 "POWERTRAIN_FAN_SWEEP" 13 "READY_TO_DRIVE" 14 "SHUTDOWN_DRIVER_WARNING" 15 "SHUTDOWN_PUMP_OFF" 16 "SHUTDOWN_FAN_OFF" 17 "SHUTDOWN_COMPLETE";
+VAL_ 111 LvState 0 "PWRUP_START" 1 "PWRUP_TSSI_ON" 2 "PWRUP_PERIPHERALS_ON" 3 "PWRUP_ACCUMULATOR_ON" 4 "PWRUP_MOTOR_PRECHARGE_ON" 5 "PWRUP_MOTOR_LV" 6 "PWRUP_MOTOR_PRECHARGE_OFF" 7 "PWRUP_SHUTDOWN_ON" 8 "MOTOR_CONTROLLER_SWITCH_SEQ" 9 "DCDC_ON" 10 "POWERTRAIN_PUMP_ON" 11 "POWERTRAIN_FAN_ON" 12 "POWERTRAIN_FAN_SWEEP" 13 "READY_TO_DRIVE" 14 "SHUTDOWN_DRIVER_WARNING" 15 "SHUTDOWN_PUMP_OFF" 16 "SHUTDOWN_FAN_OFF" 17 "SHUTDOWN_COMPLETE" 18 "PWRUP_CHECK_HASH_STATUS";
 VAL_ 112 FcState 0 "PWRUP_START" 1 "HVIL_OPEN";
+VAL_ 255 HashStatus 0 "WAITING" 1 "VALID" 2 "INVALID";
 VAL_ 255 VC_bmStatus 9 "err_running" 8 "bm_low_soc" 7 "hvil_interrupt" 6 "bm_running" 5 "precharge" 4 "init_precharge" 3 "bm_startup" 2 "bm_idle" 1 "bm_init" 0 "bm_unknown" ;
 VAL_ 255 VC_diStatus 8 "di_error" 7 "di_running" 6 "hv_start_req" 5 "ready_to_drive_req" 4 "waiting_for_driver" 3 "di_startup" 2 "di_idle" 1 "di_sts_init" 0 "di_unknown" ;
 VAL_ 255 VC_miStatus 7 "off" 6 "mi_sts_error" 5 "shutdown" 4 "running" 3 "ready" 2 "startup" 1 "sts_init" 0 "unknown" ;

--- a/firmware/projects/veh.dbc
+++ b/firmware/projects/veh.dbc
@@ -65,7 +65,6 @@ BO_ 255 FC_Status: 6 FC
  SG_ DiStatus : 8|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ MiStatus : 16|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ BmStatus : 24|8@1+ (1,0) [0|255] "" LVC, PC_SG
- SG_ UserFlag : 32|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ HashStatus : 40|8@1+ (1,0) [0|255] "" LVC, PC_SG
 
 BO_ 511 FC_msg: 8 FC

--- a/scripts/cangen/cangen/can_generator.py
+++ b/scripts/cangen/cangen/can_generator.py
@@ -165,7 +165,7 @@ def _parse_dbc_files(dbc_file: str) -> Database:
     return can_db
 
 
-def _extract_dbc_hash_version(dbc_file: str) -> int:
+def _extract_dbc_hash(dbc_file: str) -> int:
     """Generates a 64 bit integer hash of the dbc file"""
     with open(dbc_file, "r") as f:
         dbc_file_string = f.read()
@@ -240,7 +240,7 @@ def _generate_code(bus: Bus, output_dir: str):
         "tx_msgs": tx_msgs,
         "bus_name": bus.bus_name,
         "node_name": bus.node,
-        "hash_version": _extract_dbc_hash_version(bus.dbc_file_path),
+        "dbc_hash": _extract_dbc_hash(bus.dbc_file_path),
     }
 
     logger.debug("Generating code for can messages and msg registry.")

--- a/scripts/cangen/cangen/can_generator.py
+++ b/scripts/cangen/cangen/can_generator.py
@@ -4,6 +4,7 @@ Author: Samuel Parent, Andrew Iammancini, Blake Freer
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import re
@@ -164,6 +165,14 @@ def _parse_dbc_files(dbc_file: str) -> Database:
     return can_db
 
 
+def _extract_dbc_hash_version(dbc_file: str) -> int:
+    """Generates a 64 bit integer hash of the dbc file"""
+    with open(dbc_file, "r") as f:
+        dbc_file_string = f.read()
+        hash_hexadecimal = hashlib.sha256(dbc_file_string.encode()).hexdigest()[:16]
+        return int(hash_hexadecimal, 16)
+
+
 def _normalize_node_name(node_name: str) -> str:
     return node_name.upper()
 
@@ -231,6 +240,7 @@ def _generate_code(bus: Bus, output_dir: str):
         "tx_msgs": tx_msgs,
         "bus_name": bus.bus_name,
         "node_name": bus.node,
+        "hash_version": _extract_dbc_hash_version(bus.dbc_file_path),
     }
 
     logger.debug("Generating code for can messages and msg registry.")

--- a/scripts/cangen/cangen/templates/messages.hpp.jinja2
+++ b/scripts/cangen/cangen/templates/messages.hpp.jinja2
@@ -21,7 +21,7 @@ class {{ bus }};
 
 /* --------------------- CONSTANTS --------------------- */
 
-const uint64_t k{{ bus_name|capitalize }}DbcHashVersion = {{ hash_version }}U;
+const uint64_t k{{ bus_name|capitalize }}DbcHash = {{ dbc_hash }}U;
 
 /* -------------------- RX MESSAGES -------------------- */
 

--- a/scripts/cangen/cangen/templates/messages.hpp.jinja2
+++ b/scripts/cangen/cangen/templates/messages.hpp.jinja2
@@ -21,7 +21,7 @@ class {{ bus }};
 
 /* --------------------- CONSTANTS --------------------- */
 
-const uint64_t k{{ bus_name|capitalize }}DbcHash = {{ dbc_hash }}U;
+const uint64_t k{{ bus_name|capitalize }}DbcHash = {{ dbc_hash | hex }}U;
 
 /* -------------------- RX MESSAGES -------------------- */
 

--- a/scripts/cangen/cangen/templates/messages.hpp.jinja2
+++ b/scripts/cangen/cangen/templates/messages.hpp.jinja2
@@ -21,7 +21,7 @@ class {{ bus }};
 
 /* --------------------- CONSTANTS --------------------- */
 
-const uint64_t {{ bus_name|upper }}_DBC_HASH_VERSION = {{ hash_version }}U;
+const uint64_t k{{ bus_name|capitalize }}DbcHashVersion = {{ hash_version }}U;
 
 /* -------------------- RX MESSAGES -------------------- */
 

--- a/scripts/cangen/cangen/templates/messages.hpp.jinja2
+++ b/scripts/cangen/cangen/templates/messages.hpp.jinja2
@@ -19,6 +19,10 @@ namespace generated::can {
 {% set bus = bus_name+"Bus" %}
 class {{ bus }};
 
+/* --------------------- CONSTANTS --------------------- */
+
+const uint64_t {{ bus_name|upper }}_DBC_HASH_VERSION = {{ hash_version }}U;
+
 /* -------------------- RX MESSAGES -------------------- */
 
 {% for msg in rx_msgs %}


### PR DESCRIPTION
## Description
- The purpose of this PR is to add hash version generation for dbc generated files such that these are sent to boards to compare and ensure that the boards are using the same dbc file, guarenteeing there will be no errors.
- Added `_extract_dbc_hash_version` in `can_generator.py` to create a hash version for message files, based on the raw contents of the file. If anything changes, the version will change.
- Added addition of hash version to message files, creating a constant that is set to the value of `_extract_dbc_hash_version`.
- Added a new bus message that is sent by LV and received by FC to send and compare hash versions
- Modified LVController to send the hash version, and the FrontController to receive the hash version, and compare it with it's own hash version to ensure that it is the same. If it is not, it will throw an error.