### PR TITLE
Migrate from deprecated hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       # Prevent committing directly to the main branch
       - id: no-commit-to-branch
         args: [--branch, main]
-        stages: [commit]
+        stages: [pre-commit]
     
   - repo: local
     hooks:
@@ -17,6 +17,6 @@ repos:
         entry: git clang-format --style=file --staged
         language: python
         require_serial: true
-        stages: [commit]
+        stages: [pre-commit]
         additional_dependencies:
           - clang-format~=19.0


### PR DESCRIPTION
Satisfies this warning from `pre-commit`

```
[WARNING] hook id `no-commit-to-branch` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `clang-format` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this
```