### PR TITLE
APPS Pedal Tuning

### DIFF
--- a/firmware/projects/FrontController/main.cc
+++ b/firmware/projects/FrontController/main.cc
@@ -13,6 +13,7 @@
 #include "generated/can/veh_messages.hpp"
 #include "inc/app.hpp"
 #include "shared/util/mappers/linear_map.hpp"
+#include "tuning.hpp"
 
 /***************************************************************
     CAN
@@ -27,24 +28,20 @@ generated::can::PtBus pt_can_bus{bindings::pt_can_base};
 ***************************************************************/
 using shared::util::LinearMap;
 
-// voltages measured at the STM ADC (post buffer circuit)
-const float apps1_vol_pos_0 = 2.781;  // aim for 2.8V
-const float apps1_vol_pos_100 = 1.809;
-const float m1 = 100 / (apps1_vol_pos_100 - apps1_vol_pos_0);
-const float b1 = -m1 * apps1_vol_pos_0;
-auto accel_pedal1_map = LinearMap<float>{m1, b1};
+const float apps1_m =
+    100 / (tuning::apps1_volt_pos_100 - tuning::apps1_volt_pos_0);
+const float apps1_b = -apps1_m * tuning::apps1_volt_pos_0;
+auto accel_pedal1_map = LinearMap<float>{apps1_m, apps1_b};
 AnalogInput accel_pedal_1{bindings::accel_pedal_sensor1, &accel_pedal1_map};
 
-const float apps2_vol_pos_0 = 0.536;  // aim for 0.55V
-const float apps2_vol_pos_100 = 1.480;
-const float m2 = 100 / (apps2_vol_pos_100 - apps2_vol_pos_0);
-const float b2 = -m2 * apps2_vol_pos_0;
-auto accel_pedal2_map = LinearMap<float>{m2, b2};
+const float apps2_m =
+    100 / (tuning::apps2_volt_pos_100 - tuning::apps2_volt_pos_0);
+const float apps2_b = -apps2_m * tuning::apps2_volt_pos_0;
+auto accel_pedal2_map = LinearMap<float>{apps2_m, apps2_b};
 AnalogInput accel_pedal_2{bindings::accel_pedal_sensor2, &accel_pedal2_map};
 
-const float kPressureRange = 2000;
-
 // See datasheets/race_grade/RG_SPEC-0030_M_APT_G2_DTM.pdf
+const float kPressureRange = 2000;
 auto brake_pedal_front_map =
     LinearMap<float>{0.378788f * kPressureRange, -0.125f * kPressureRange};
 AnalogInput brake_pedal_front{bindings::brake_pressure_sensor,

--- a/firmware/projects/FrontController/main.cc
+++ b/firmware/projects/FrontController/main.cc
@@ -213,6 +213,18 @@ int main(void) {
         UpdateControls();
         veh_can_bus.Send(fc_status);
 
+        // test pedals
+        veh_can_bus.Send(TxFC_msg{
+            .fc_apps1 = static_cast<uint16_t>(
+                100 * bindings::accel_pedal_sensor1.ReadVoltage()),
+            .fc_apps2 = static_cast<uint16_t>(
+                100 * bindings::accel_pedal_sensor2.ReadVoltage()),
+            .fc_bpps = static_cast<uint16_t>(
+                100 * bindings::brake_pressure_sensor.ReadVoltage()),
+            .fc_steering_angle = static_cast<uint16_t>(
+                100 * bindings::steering_angle_sensor.ReadVoltage()),
+        });
+
         bindings::debug_led.Set(state);
         state = !state;
 

--- a/firmware/projects/FrontController/tuning.hpp
+++ b/firmware/projects/FrontController/tuning.hpp
@@ -1,0 +1,19 @@
+namespace tuning {
+
+/*
+To measure, open BusMaster, load the veh.dbc, and read the `FC_apps_debug`
+message. https://macformula.github.io/racecar/tutorials/busmaster/
+
+Read the `raw_volt` signals when the pedal is released (pos_0) and fully
+depressed (pos_100). Set these value accordingly.
+
+To verify, recompile and flash FrontController and look at the same message.
+The `apps1_pos` and `apps2_pos` signals should both be 0.0 when the pedal
+is released and 100.0 when fully depressed. +- 0.5% is acceptable.
+*/
+const float apps1_volt_pos_0 = 2.781;  // aim for 2.8V
+const float apps1_volt_pos_100 = 1.809;
+const float apps2_volt_pos_0 = 0.536;  // aim for 0.55V
+const float apps2_volt_pos_100 = 1.480;
+
+}  // namespace tuning

--- a/firmware/projects/veh.dbc
+++ b/firmware/projects/veh.dbc
@@ -67,13 +67,15 @@ BO_ 255 FC_Status: 6 FC
  SG_ BmStatus : 24|8@1+ (1,0) [0|255] "" LVC, PC_SG
  SG_ DbcHashStatus : 40|8@1+ (1,0) [0|255] "" LVC, PC_SG
 
-BO_ 511 FC_msg: 8 FC
- SG_ FC_hvilSts : 60|1@1+ (1,0) [0|1] ""  PC_SG
- SG_ FC_steeringAngle : 48|12@1+ (1,0) [0|4095] ""  PC_SG
+BO_ 511 FC_apps_debug: 8 FC
+ SG_ apps1_raw_volt : 0|16@1+ (0.001,0) [0|0] "volt"  PC_SG
+ SG_ apps2_raw_volt : 16|16@1+ (0.001,0) [0|0] "volt"  PC_SG
+ SG_ apps1_pos : 32|16@1+ (0.1,0) [0|0] "percent" PC_SG
+ SG_ apps2_pos : 48|16@1+ (0.1,0) [0|0] "percent" PC_SG
+
+BO_ 512 FC_debug: 8 FC
  SG_ FC_bpps : 32|12@1+ (1,0) [0|4095] ""  PC_SG
- SG_ FC_apps2 : 16|12@1+ (1,0) [0|4095] ""  PC_SG
- SG_ FC_apps1 : 0|12@1+ (1,0) [0|4095] ""  PC_SG
- SG_ FC_readyToDriveBtn_n : 61|1@1+ (1,0) [0|1] ""  PC_SG
+ SG_ FC_steeringAngle : 48|12@1+ (1,0) [0|4095] ""  PC_SG
 
 BO_ 256 FC_cmd: 1 PC_SG
  SG_ FC_readyToDriveSpeaker : 1|1@1+ (1,0) [0|1] ""  FC


### PR DESCRIPTION
Sets up the tuning system by creating CAN messages and easy-to-understand constants (see `FrontController/tuning.hpp`)

Tunes the pedals as installed in early April