### PR TITLE
Improve LookupTable with `span`

### DIFF
--- a/firmware/projects/Demo/Mapper/main.cc
+++ b/firmware/projects/Demo/Mapper/main.cc
@@ -44,12 +44,19 @@ int main(void) {
     }
 
     {
-        std::cout << "Lookup Table" << std::endl;
-        const double lut_data[][2] = {{-2., 4.}, {-1., 1.}, {0., 0.},
-                                      {1., 1.},  {2., 4.},  {3., 9.}};
+        using shared::util::LookupTable;
 
-        constexpr int lut_length = (sizeof(lut_data)) / (sizeof(lut_data[0]));
-        shared::util::LookupTable<lut_length, double> f{lut_data};
+        std::cout << "Lookup Table" << std::endl;
+        auto data = std::to_array<LookupTable<float>::Entry>({
+            {-2., 4.},
+            {-1., 1.},
+            {0., 0.},
+            {1., 1.},
+            {2., 4.},
+            {3., 9.},
+        });
+
+        shared::util::LookupTable f{data};
 
         expect_eq(f.Evaluate(-1.5), 2.5);
         expect_eq(f.Evaluate(0.5), 0.5);

--- a/firmware/projects/FrontController/control-system/src/driver_interface.cc
+++ b/firmware/projects/FrontController/control-system/src/driver_interface.cc
@@ -12,23 +12,19 @@ bool isInRange(T fractionIn) {
 
 DriverInterface::Output DriverInterface::Update(const Input input,
                                                 const int time_ms) {
-    const double accel_lut_data[][2] = {
-        {0., 0.},
-        {1., 1},
-    };
-    static constexpr int lut_length =
-        sizeof(accel_lut_data) / sizeof(accel_lut_data[0]);
-    const shared::util::LookupTable<lut_length, double> accel_pedal_map{
-        accel_lut_data};
+    using shared::util::LookupTable;
 
-    const double brake_lut_data[][2] = {
-        {0., 0.},
-        {1., 1},
-    };
-    static constexpr int brake_lut_length =
-        sizeof(brake_lut_data) / sizeof(brake_lut_data[0]);
-    const shared::util::LookupTable<brake_lut_length, double> brake_pedal_map{
-        brake_lut_data};
+    auto apps_pedal_map = std::to_array<LookupTable<float>::Entry>({
+        {0, 0},
+        {1, 1},
+    });
+    LookupTable accel_pedal_map{apps_pedal_map};
+
+    auto bpps_pedal_map = std::to_array<LookupTable<float>::Entry>({
+        {0, 0},
+        {1, 1},
+    });
+    LookupTable brake_pedal_map{bpps_pedal_map};
 
     Output out;
 

--- a/firmware/projects/FrontController/control-system/src/vehicle_dynamics_calc.cc
+++ b/firmware/projects/FrontController/control-system/src/vehicle_dynamics_calc.cc
@@ -36,18 +36,20 @@ float TorqueRequest::Update(float driver_torque_request,
 }
 
 float CreateTorqueVectoringFactor(float steering_angle) {
+    using shared::util::LookupTable;
     float absolute_steering_angle = std::abs(steering_angle);
 
-    static const float table_data[][2] = {{0.0, 1.0f},    {5.0, 0.934f},
-                                          {10.0, 0.87f},  {15.0, 0.808f},
-                                          {20.0, 0.747f}, {25.0, 0.683f}};
+    auto tv_lut = std::to_array<LookupTable<float>::Entry>({
+        {0.0, 1.0f},
+        {5.0, 0.934f},
+        {10.0, 0.87f},
+        {15.0, 0.808f},
+        {20.0, 0.747f},
+        {25.0, 0.683f},
+    });
+    LookupTable tv{tv_lut};
 
-    static constexpr int table_length =
-        (sizeof(table_data)) / (sizeof(table_data[0]));
-
-    static shared::util::LookupTable<table_length> tv_lookup_table{table_data};
-
-    return tv_lookup_table.Evaluate(absolute_steering_angle);
+    return tv.Evaluate(absolute_steering_angle);
 }
 
 TorqueVector AdjustTorqueVectoring(float steering_angle) {

--- a/firmware/projects/TMS/inc/tempsensor.hpp
+++ b/firmware/projects/TMS/inc/tempsensor.hpp
@@ -8,7 +8,7 @@ namespace tempsensor {
 
 /// This table is directly copied from Table 4 of the temperature sensor
 /// datasheet. `datasheets/energus/Datasheet_with_VTC6_rev_A(2021-10-26).pdf`
-const float ts_table[][2] = {
+auto ts_table = std::to_array<shared::util::LookupTable<float>::Entry>({
     // clang-format off
     {1.30f, 120.0f},
     {1.31f, 115.0f},
@@ -42,11 +42,10 @@ const float ts_table[][2] = {
     {2.38f, -25.0f},
     {2.40f, -30.0f},
     {2.42f, -35.0f},
-    {2.44f, -40.0f}
+    {2.44f, -40.0f},
     // clang-format on
-};
-constexpr int lut_length = (sizeof(ts_table)) / (sizeof(ts_table[0]));
-const shared::util::LookupTable<lut_length> volt_ts_to_degC{ts_table};
+});
+const shared::util::LookupTable volt_ts_to_degC{ts_table};
 
 /// Calculate the voltage at the temperature sensor from the voltage at the STM.
 /// They are not equal because there is a non-unity gain buffer between them.

--- a/firmware/projects/TMS/main.cc
+++ b/firmware/projects/TMS/main.cc
@@ -26,15 +26,13 @@ TempSensor temp_sensors[] = {
 constexpr int kSensorCount = sizeof(temp_sensors) / sizeof(temp_sensors[0]);
 
 /// Spin the fan faster when the acculumator is hotter.
-const float fan_lut_data[][2] = {
+using shared::util::LookupTable;
+auto fan_lut_data = std::to_array<LookupTable<float>::Entry>({
     {19, 0},
     {20, 30},
     {50, 100},
-};
-
-constexpr int fan_lut_length =
-    (sizeof(fan_lut_data) / (sizeof(fan_lut_data[0])));
-shared::util::LookupTable<fan_lut_length> fan_temp_lut{fan_lut_data};
+});
+LookupTable fan_temp_lut{fan_lut_data};
 
 FanContoller fan_controller{bindings::fan_controller_pwm, fan_temp_lut};
 

--- a/firmware/shared/util/mappers/lookup_table.hpp
+++ b/firmware/shared/util/mappers/lookup_table.hpp
@@ -1,8 +1,9 @@
 /// @author Blake Freer
-/// @date 2023-12-04
+/// @date 2025-04
 
 #pragma once
 
+#include <span>
 #include <type_traits>
 
 #include "mapper.hpp"
@@ -11,45 +12,48 @@ namespace shared::util {
 
 /// @brief Linearly interpolates the input value according to a table to form a
 /// piecewise lineary approximation of a function.
-/// @tparam row_count_ The number of rows in the lookup table. Must be a compile
-/// time constant.
 /// @note If the input `key` is less than the lowest key in the table, the the
 /// value of the lowest key is returned, and similarly for the largest key.
-template <int row_count_, typename T = float>
+template <typename T = float>
     requires std::is_floating_point_v<T>
 class LookupTable : public Mapper<T> {
 public:
+    struct Entry {
+        T key;
+        T value;
+    };
+
     /// @warning The table's first columns (keys) must be sorted in increasing
     /// order.
-    LookupTable(T const (*table)[2]) : table_(table) {}
+    explicit LookupTable(std::span<Entry> table) : table_(table) {}
 
     inline T Evaluate(T key) const override {
         int least_greater_idx = 0;
 
         // Find next greatest element in keys_, assumes keys_ is sorted
-        while (table_[least_greater_idx][0] < key &&
-               least_greater_idx < row_count_) {
+        while (table_[least_greater_idx].key < key &&
+               least_greater_idx < table_.size()) {
             least_greater_idx += 1;
         }
 
         // If key is outside of range, return edge value
         if (least_greater_idx == 0) {
-            return table_[0][1];
+            return table_.front().value;
         }
-        if (least_greater_idx == row_count_) {
-            return table_[row_count_ - 1][1];
+        if (least_greater_idx == table_.size()) {
+            return table_.back().value;
         }
 
-        auto [prev_key, prev_val] = table_[least_greater_idx - 1];
-        auto [next_key, next_val] = table_[least_greater_idx];
+        auto prev = table_[least_greater_idx - 1];
+        auto next = table_[least_greater_idx];
 
-        T fraction = (key - prev_key) / (next_key - prev_key);
+        T fraction = (key - prev.key) / (next.key - prev.key);
 
-        return (1 - fraction) * prev_val + fraction * next_val;
+        return (1 - fraction) * prev.value + fraction * next.value;
     }
 
 private:
-    const T (*table_)[2];
+    const std::span<Entry> table_;
 };
 
 }  // namespace shared::util

--- a/firmware/shared/util/mappers/test_lookup_table.cc
+++ b/firmware/shared/util/mappers/test_lookup_table.cc
@@ -6,18 +6,14 @@
 
 namespace shared::util {
 
-// clang-format off
-const float data[][2] = {
-	{-11.f, 5.f},
-	{ -1.f, 0.f},
-	{  0.f, 3.f},
-	{  5.f, 2.f}
-};
-// clang-format on
+auto data = std::to_array<LookupTable<float>::Entry>({
+    {-11.f, 5.f},
+    {-1.f, 0.f},
+    {0.f, 3.f},
+    {5.f, 2.f},
+});
 
-constexpr size_t data_rows = sizeof(data) / sizeof(data[0]);
-
-LookupTable<data_rows> lut{data};
+LookupTable<float> lut{data};
 
 TEST(LookupTableTest, LowSideClamp) {
     EXPECT_FLOAT_EQ(lut.Evaluate(-12.f), 5.f);
@@ -29,8 +25,8 @@ TEST(LookupTableTest, HighSideClamp) {
 
 TEST(LookupTableTest, KeyPoints) {
     // Lookup table should return exact value at specified points
-    for (size_t i = 0; i < data_rows; i++) {
-        EXPECT_FLOAT_EQ(lut.Evaluate(data[i][0]), data[i][1]);
+    for (const auto& entry : data) {
+        EXPECT_FLOAT_EQ(lut.Evaluate(entry.key), entry.value);
     }
 }
 


### PR DESCRIPTION
previously, `shared::util::LookupTable` held its own data in an `std::array`. This required the class to be templated on the array size.

This is an issue since we intend to use `LookupTable` to hold driver-specific tuning curves which will likely have different sizes. The templated size prevents reconstruction at runtime.

This PR changes LookupTable to use C++20 `std::span` which is a view into an external array, solving the problem. It also uses a struct `Entry{key, value}` to make the first and second elements very explicit, whereas before each entry was just a 2-element array.

Notice that constructing an LUT is also much simpler.

before:
```c++
const double lut_data[][2] = {
    {-2., 4.},
    {-1., 1.},
    {0., 0.},
    {1., 1.},
    {2., 4.},
    {3., 9.}
};
constexpr int lut_length = (sizeof(lut_data)) / (sizeof(lut_data[0]));
shared::util::LookupTable<lut_length, double> f{lut_data};
```

after:
```c++
auto data = std::to_array<LookupTable<float>::Entry>({
    {-2., 4.},
    {-1., 1.},
    {0., 0.},
    {1., 1.},
    {2., 4.},
    {3., 9.},
});

shared::util::LookupTable f{data};
```

I also added a static `LookupTable::Evaluate` function which can operate on such a span without creating a LookupTable object.