### PR TITLE
Upgrade clang-format

### DIFF
--- a/.github/workflows/pr-format-check.yml
+++ b/.github/workflows/pr-format-check.yml
@@ -11,24 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: clang-format Check
+        uses: jidicula/clang-format-action@v4.15.0
         with:
-          fetch-depth: 0
-
-      - name: Set up clang-format
-        run: sudo apt-get install clang-format -y
-
-      - name: Fetch main branch
-        run: git fetch origin main:main
-
-      - name: Check code formatting
-        id: check_formatting
-        run: |
-          if git clang-format --style=file:firmware/.clang-format --diff $(git merge-base HEAD main) -v > clang_format_output.txt; then
-            echo "Code formatting is already correct."
-          else
-            echo "Code formatting changes detected."
-            cat clang_format_output.txt
-            exit 1
-          fi
+          check-path: firmware
+          clang-format-version: 19

--- a/firmware/mcal/cli/periph/can.hpp
+++ b/firmware/mcal/cli/periph/can.hpp
@@ -18,7 +18,7 @@ namespace mcal::cli::periph {
 
 class CanBase : public shared::periph::CanBase {
 public:
-    CanBase(std::string can_iface) : iface_(can_iface){};
+    CanBase(std::string can_iface) : iface_(can_iface) {};
 
     void Setup() {
         std::cout << std::format("can interface: {}", iface_) << std::endl;

--- a/firmware/mcal/linux/periph/can.cc
+++ b/firmware/mcal/linux/periph/can.cc
@@ -12,8 +12,9 @@
 #include "vcan/vcan.hpp"
 
 static can_frame to_can_frame(const shared::can::RawMessage& msg) {
-    struct can_frame frame {
-        .can_id = msg.id, .can_dlc = msg.data_length,
+    struct can_frame frame{
+        .can_id = msg.id,
+        .can_dlc = msg.data_length,
     };
     std::memcpy(&frame.data, msg.data, msg.data_length);
     return frame;

--- a/firmware/mcal/linux/periph/digital_input.cc
+++ b/firmware/mcal/linux/periph/digital_input.cc
@@ -6,7 +6,7 @@
 
 namespace mcal::lnx::periph {
 
-DigitalInput::DigitalInput(std::string name) : name_(name){};
+DigitalInput::DigitalInput(std::string name) : name_(name) {};
 
 bool DigitalInput::Read() {
     int value;

--- a/firmware/mcal/stm32f/periph/analog_input.hpp
+++ b/firmware/mcal/stm32f/periph/analog_input.hpp
@@ -21,7 +21,9 @@ class AnalogInput : public shared::periph::AnalogInput {
 public:
     AnalogInput(ADC_HandleTypeDef* hadc, uint32_t adc_channel,
                 float system_volts = 3.3f)
-        : hadc_(hadc), adc_channel_(adc_channel), system_volts_(system_volts){};
+        : hadc_(hadc),
+          adc_channel_(adc_channel),
+          system_volts_(system_volts) {};
 
     float ReadVoltage() override {
         Start();

--- a/firmware/projects/Dashboard/platforms/stm32/hal_stm_lvgl/screen_driver.c
+++ b/firmware/projects/Dashboard/platforms/stm32/hal_stm_lvgl/screen_driver.c
@@ -16,7 +16,7 @@
 
 #define LCD_SCREEN_WIDTH NT35510_480X800_HEIGHT
 #define LCD_SCREEN_HEIGHT NT35510_480X800_WIDTH
-#define FRAMEBUFFER_SIZE (uint32_t) LCD_SCREEN_HEIGHT* LCD_SCREEN_WIDTH
+#define FRAMEBUFFER_SIZE (uint32_t)LCD_SCREEN_HEIGHT* LCD_SCREEN_WIDTH
 #define DMA_XFERS_NEEDED \
     FRAMEBUFFER_SIZE /   \
         2  // We need half as many transfers because the buffer is an array of

--- a/firmware/projects/Demo/AnalogPWM/platforms/cli/bindings.cc
+++ b/firmware/projects/Demo/AnalogPWM/platforms/cli/bindings.cc
@@ -1,8 +1,9 @@
+#include "../../bindings.hpp"
+
 #include <unistd.h>
 
 #include <iostream>
 
-#include "../../bindings.hpp"
 #include "mcal/cli/periph/analog_output.hpp"
 #include "mcal/cli/periph/pwm.hpp"
 #include "shared/periph/analog_output.hpp"

--- a/firmware/projects/Demo/BasicIO/platforms/cli/bindings.cc
+++ b/firmware/projects/Demo/BasicIO/platforms/cli/bindings.cc
@@ -1,9 +1,10 @@
 /// @author Blake Freer
 /// @date 2023-12-25
 
+#include "../../bindings.hpp"
+
 #include <iostream>
 
-#include "../../bindings.hpp"
 #include "mcal/cli/periph/gpio.hpp"
 #include "shared/periph/gpio.hpp"
 

--- a/firmware/projects/Demo/Blink/platforms/cli/bindings.cc
+++ b/firmware/projects/Demo/Blink/platforms/cli/bindings.cc
@@ -1,8 +1,9 @@
+#include "../../bindings.hpp"
+
 #include <unistd.h>
 
 #include <iostream>
 
-#include "../../bindings.hpp"
 #include "mcal/cli/periph/gpio.hpp"
 #include "shared/periph/gpio.hpp"
 

--- a/firmware/projects/Demo/CAN/Receive/platforms/cli/bindings.cc
+++ b/firmware/projects/Demo/CAN/Receive/platforms/cli/bindings.cc
@@ -1,11 +1,12 @@
 /// @author Samuel Parent
 /// @date 2024-01-16
 
+#include "../../bindings.hpp"
+
 #include <chrono>
 #include <iostream>
 #include <thread>
 
-#include "../../bindings.hpp"
 #include "mcal/cli/periph/can.hpp"
 #include "mcal/cli/periph/gpio.hpp"
 #include "shared/periph/can.hpp"

--- a/firmware/projects/Demo/CAN/Receive/platforms/linux/bindings.cc
+++ b/firmware/projects/Demo/CAN/Receive/platforms/linux/bindings.cc
@@ -1,8 +1,9 @@
+#include "../../bindings.hpp"
+
 #include <unistd.h>
 
 #include <iostream>
 
-#include "../../bindings.hpp"
 #include "mcal/linux/periph/can.hpp"
 #include "mcal/linux/periph/digital_output.hpp"
 

--- a/firmware/projects/Demo/CAN/Send/platforms/cli/bindings.cc
+++ b/firmware/projects/Demo/CAN/Send/platforms/cli/bindings.cc
@@ -1,10 +1,11 @@
 /// @author Samuel Parent
 /// @date 2024-01-16
 
+#include "../../bindings.hpp"
+
 #include <chrono>
 #include <thread>
 
-#include "../../bindings.hpp"
 #include "mcal/cli/periph/can.hpp"
 #include "mcal/cli/periph/gpio.hpp"
 #include "shared/periph/can.hpp"

--- a/firmware/projects/Demo/CAN/Send/platforms/linux/bindings.cc
+++ b/firmware/projects/Demo/CAN/Send/platforms/linux/bindings.cc
@@ -1,8 +1,9 @@
+#include "../../bindings.hpp"
+
 #include <unistd.h>
 
 #include <iostream>
 
-#include "../../bindings.hpp"
 #include "mcal/linux/periph/can.hpp"
 #include "mcal/linux/periph/digital_input.hpp"
 

--- a/firmware/validation/sil/signals.proto
+++ b/firmware/validation/sil/signals.proto
@@ -6,20 +6,24 @@ option go_package = ".sil";
 
 service Signals {
     rpc EnumerateRegisteredSignals(EnumerateRegisteredSignalsRequest)
-        returns(EnumerateRegisteredSignalsResponse) {}
-    rpc WriteSignal(WriteSignalRequest) returns(WriteSignalResponse) {}
-    rpc ReadSignal(ReadSignalRequest) returns(ReadSignalResponse) {}
-    rpc RegisterSignal(RegisterSignalRequest) returns(RegisterSignalResponse) {}
+        returns (EnumerateRegisteredSignalsResponse) {}
+    rpc WriteSignal(WriteSignalRequest) returns (WriteSignalResponse) {}
+    rpc ReadSignal(ReadSignalRequest) returns (ReadSignalResponse) {}
+    rpc RegisterSignal(RegisterSignalRequest) returns (RegisterSignalResponse) {
+    }
 }
 
 enum SignalType {
-    SIGNAL_TYPE_UNKNOWN = 0; SIGNAL_TYPE_ANALOG = 1; SIGNAL_TYPE_DIGITAL = 2;
-        SIGNAL_TYPE_PWM = 3;
+    SIGNAL_TYPE_UNKNOWN = 0;
+    SIGNAL_TYPE_ANALOG = 1;
+    SIGNAL_TYPE_DIGITAL = 2;
+    SIGNAL_TYPE_PWM = 3;
 }
 
 enum SignalDirection {
-    SIGNAL_DIRECTION_UNKNOWN = 0; SIGNAL_DIRECTION_INPUT = 1;
-        SIGNAL_DIRECTION_OUTPUT = 2;
+    SIGNAL_DIRECTION_UNKNOWN = 0;
+    SIGNAL_DIRECTION_INPUT = 1;
+    SIGNAL_DIRECTION_OUTPUT = 2;
 }
 
 message AnalogSignal {


### PR DESCRIPTION
Our clang-format action was stuck on v18 and couldn't be updated. This PR uses a 3rd party clang-format action instead. Now the action and `pre-commit` agree (as they always should have)

Formats all code for v19