### PR TITLE
Configurable pedal-to-torque mapping

### DIFF
--- a/projects/front_controller/include/tuning.hpp
+++ b/projects/front_controller/include/tuning.hpp
@@ -19,12 +19,41 @@ struct Profile {
 
 // Map a [0%, 100%] pedal position to [0%, 100%] torque request.
 // Linearly interpolated between keypoints.
-constexpr auto pedal_to_torque = std::to_array<macfe::LookupTable::Entry>({
+constexpr auto pedal_to_torque_linear = std::to_array<macfe::LookupTable::Entry>({
     // Syntax: {pedal pos, torque}. Add more rows as desired.
     // Must be sorted by increasing pedal position.
     {0.0f, 0.0f},
     {100.f, 100.f},
 });
+
+// Same as above, but with a Quadratic Curve instead of Linear (torque = pedal^2/100)
+constexpr auto pedal_to_torque_quadratic = std::to_array<macfe::LookupTable::Entry>({
+    {0.f, 0.f},
+    {25.f, 6.25f},
+    {50.f, 25.f},
+    {75.f, 56.25f},  
+    {100.f, 100.f},
+});
+
+// The type of pedal map to use. Can be switched in the system
+enum class PedalMapType {
+    Linear,
+    Quadratic,
+};
+
+// The active pedal map to use. Change this to switch between Quadratic and Linear maps
+constexpr PedalMapType active_pedal_map = PedalMapType::Quadratic;
+
+
+// Get the active pedal map based on the value of active_pedal_map
+constexpr const auto& get_pedal_map() {
+    if constexpr (active_pedal_map == PedalMapType::Linear) {
+        return pedal_to_torque_linear;
+    } 
+    else {
+        return pedal_to_torque_quadratic;
+    }
+}
 
 constexpr Profile GetProfile(generated::can::RxDashStatus::Profile_t profile) {
     using enum generated::can::RxDashStatus::Profile_t;

--- a/projects/front_controller/include/tuning.hpp
+++ b/projects/front_controller/include/tuning.hpp
@@ -19,21 +19,24 @@ struct Profile {
 
 // Map a [0%, 100%] pedal position to [0%, 100%] torque request.
 // Linearly interpolated between keypoints.
-constexpr auto pedal_to_torque_linear = std::to_array<macfe::LookupTable::Entry>({
-    // Syntax: {pedal pos, torque}. Add more rows as desired.
-    // Must be sorted by increasing pedal position.
-    {0.0f, 0.0f},
-    {100.f, 100.f},
-});
+constexpr auto pedal_to_torque_linear =
+    std::to_array<macfe::LookupTable::Entry>({
+        // Syntax: {pedal pos, torque}. Add more rows as desired.
+        // Must be sorted by increasing pedal position.
+        {0.0f, 0.0f},
+        {100.f, 100.f},
+    });
 
-// Same as above, but with a Quadratic Curve instead of Linear (torque = pedal^2/100)
-constexpr auto pedal_to_torque_quadratic = std::to_array<macfe::LookupTable::Entry>({
-    {0.f, 0.f},
-    {25.f, 6.25f},
-    {50.f, 25.f},
-    {75.f, 56.25f},  
-    {100.f, 100.f},
-});
+// Same as above, but with a Quadratic Curve instead of Linear (torque =
+// pedal^2/100)
+constexpr auto pedal_to_torque_quadratic =
+    std::to_array<macfe::LookupTable::Entry>({
+        {0.f, 0.f},
+        {25.f, 6.25f},
+        {50.f, 25.f},
+        {75.f, 56.25f},
+        {100.f, 100.f},
+    });
 
 // The type of pedal map to use. Can be switched in the system
 enum class PedalMapType {
@@ -41,16 +44,15 @@ enum class PedalMapType {
     Quadratic,
 };
 
-// The active pedal map to use. Change this to switch between Quadratic and Linear maps
+// The active pedal map to use. Change this to switch between Quadratic and
+// Linear maps
 constexpr PedalMapType active_pedal_map = PedalMapType::Quadratic;
-
 
 // Get the active pedal map based on the value of active_pedal_map
 constexpr const auto& get_pedal_map() {
     if constexpr (active_pedal_map == PedalMapType::Linear) {
         return pedal_to_torque_linear;
-    } 
-    else {
+    } else {
         return pedal_to_torque_quadratic;
     }
 }

--- a/projects/front_controller/include/tuning.hpp
+++ b/projects/front_controller/include/tuning.hpp
@@ -46,7 +46,7 @@ enum class PedalMapType {
 
 // The active pedal map to use. Change this to switch between Quadratic and
 // Linear maps
-constexpr PedalMapType active_pedal_map = PedalMapType::Quadratic;
+constexpr PedalMapType active_pedal_map = PedalMapType::Linear;
 
 // Get the active pedal map based on the value of active_pedal_map
 constexpr const auto& get_pedal_map() {

--- a/projects/front_controller/src/vehicle_dynamics/vehicle_dynamics.cc
+++ b/projects/front_controller/src/vehicle_dynamics/vehicle_dynamics.cc
@@ -89,7 +89,7 @@ void Update_100Hz(void) {
         tv = AdjustTorqueVectoring(sensors::driver::GetSteeringWheel());
     }
 
-    float torque = macfe::LookupTable::Evaluate(tuning::pedal_to_torque,
+    float torque = macfe::LookupTable::Evaluate(tuning::get_pedal_map(),
                                                 driver_torque_request);
 
     left_request = {


### PR DESCRIPTION
Overview
Implemented configurable pedal-to-torque mapping to allow different response curves.

Changes
- Added quadratic lookup table in tuning.hpp
- Introduced PedalMapType enum for selecting mapping
- Implemented get_pedal_map() 
- Updated torque evaluation to use selected mapping

Closes #558